### PR TITLE
Remove restriction on object following an Opening Excl GW, Bug fix cl…

### DIFF
--- a/src/views/flow_p0010_subflows_vw.sql
+++ b/src/views/flow_p0010_subflows_vw.sql
@@ -5,6 +5,7 @@ as
            when i_sbfl.sbfl_status = 'split' then 'fa fa-share-alt'
            when i_sbfl.sbfl_status = 'in subprocess' then 'fa fa-share-alt'
            when i_sbfl.sbfl_status = 'waiting at gateway' then 'fa fa-hand-stop-o'
+           when i_sbfl.sbfl_status = 'waiting for timer' then 'fa fa-clock-o'
            when i_sbfl.is_multistep = 'n' then 'clickable-action next-subflow-step-link fa fa-sign-out'
            when i_sbfl.is_multistep = 'y' then 'clickable-action next-subflow-multistep-link fa fa-tasks'
          end as class_string


### PR DESCRIPTION
Remove restriction on object following an Opening Excl GW:
- opening exclusive gateway now calls flow_next_step rather than just assuming next step is a bpmn:task (which is not always true!).  Now you can do anything after opening an exclusive gateway
Bug fix closing Inclusive GW Marker
- Opening GW was left as the Last_completed_activity after an closing Inclusive GW merged.  Now fixed so that the closing gateway is the last object.
- merged a couple of queries in next_branch to optimise / simplify code.