### PR TITLE
bound evts on tasks, terminateEndEvent in SubP

### DIFF
--- a/src/plsql/flow_timers_pkg.pkb
+++ b/src/plsql/flow_timers_pkg.pkb
@@ -257,12 +257,6 @@ as
       , l_repeat_times
       )
     ;
-    update flow_subflows sbfl
-       set sbfl.sbfl_has_events = sbfl.sbfl_has_events||':T'
-     where sbfl.sbfl_id = pi_sbfl_id
-       and sbfl.sbfl_prcs_id = pi_prcs_id
-    ;
-
   end start_timer;
 
 /******************************************************************************


### PR DESCRIPTION
- extends timer boundary conditions (interrupting & non interrupting) to bpmn:tasks
- fixes a problem closing or not-closing orphan subflows in subProcesses
- extends terminateEndEvents to subProcesses (issue #39)
