### PR TITLE
API tidy up, timer boundary events on userTask

### DIFF
--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -20,7 +20,7 @@ as
     return l_dgrm_name;
   end get_dgrm_name;
   
-  function get_dgrm_id    --- currently also exists in flow_engine - fix FFA41
+  function get_dgrm_id    --- FFA50 currently also exists in flow_engine - delete once function next_multistep_exists deleted
   (
     p_prcs_id in flow_processes.prcs_id%type
   ) return flow_processes.prcs_dgrm_id%type
@@ -54,10 +54,10 @@ as
     ;
   
     return
-      flow_create
+      flow_engine.flow_create
       (
-        pi_dgrm_id   => l_dgrm_id
-      , pi_prcs_name => pi_prcs_name
+        p_dgrm_id   => l_dgrm_id
+      , p_prcs_name => pi_prcs_name
       )
     ;
   
@@ -71,27 +71,11 @@ as
   is
     l_ret flow_processes.prcs_id%type;
   begin
-    apex_debug.message(p_message => 'Begin flow_create', p_level => 3) ;
-    insert 
-      into  flow_processes prcs
-          ( prcs.prcs_name
-          , prcs.prcs_dgrm_id
-          , prcs.prcs_status
-          , prcs.prcs_init_ts
-          , prcs.prcs_last_update
-          )
-    values
-          ( pi_prcs_name
-          , pi_dgrm_id
-          , 'created'
-          , systimestamp
-          , systimestamp
-          )
-      returning prcs.prcs_id into l_ret
+    return flow_engine.flow_create
+           ( p_dgrm_id => pi_dgrm_id
+           , p_prcs_name => pi_prcs_name
+           )
     ;
-    apex_debug.message(p_message => 'End flow_create', p_level => 3) ;
-
-    return l_ret;
   end flow_create;
 
   procedure flow_create
@@ -119,72 +103,12 @@ as
     l_prcs_id flow_processes.prcs_id%type;
   begin
     l_prcs_id :=
-      flow_create
+      flow_engine.flow_create
       (
-        pi_dgrm_id   => pi_dgrm_id
-      , pi_prcs_name => pi_prcs_name
+        p_dgrm_id   => pi_dgrm_id
+      , p_prcs_name => pi_prcs_name
       );
   end flow_create;
-
-  /*function next_step_exists -- not using this now.  Needs checking. FFA41 remove PROCESS
-  ( p_process_id in flow_processes.prcs_id%type
-  ,  p_subflow_id in flow_subflows.sbfl_id%type
-  ) return boolean
-  is
-    l_next_count number;
-    l_dgrm_id    flow_diagrams.dgrm_id%type;
-    l_return     boolean;
-  begin
-    apex_debug.message(p_message => 'Begin next_step_exists', p_level => 3) ;
-    l_dgrm_id := get_dgrm_id( p_prcs_id => p_process_id );
-
-    if p_subflow_id is not null then
-      select count(*)                        
-        into l_next_count
-        from flow_subflows sbfl
-           , flow_objects   objt
-      where sbfl.sbfl_prcs_id = p_process_id
-        and sbfl.sbfl_id = p_subflow_id
-        and  objt.objt_dgrm_id = l_dgrm_id
-        and  objt.objt_bpmn_id = sbfl.sbfl_current
-        and (  objt.objt_tag_name != 'bpmn:endEvent'
-            or (    objt.objt_tag_name = 'bpmn:endEvent'
-                and objt.objt_type != 'PROCESS'
-               )
-            or objt.objt_tag_name = 'bpmn:startEvent'
-            )
-      ;
-      
-      l_return := ( l_next_count > 0 );
-    else 
-      l_return := false;
-    end if;
-    
-    return l_return;
-  exception
-    when others
-    then
-      raise;
-  end next_step_exists; 
-
-  function next_step_exists_yn 
-  ( p_process_id in flow_processes.prcs_id%type
-  , p_subflow_id in flow_subflows.sbfl_id%type
-  ) return varchar2
-  is
-      l_ret boolean;
-  begin
-      l_ret := next_step_exists
-              ( p_process_id => p_process_id
-              , p_subflow_id => p_subflow_id
-              );
-      if l_ret = true
-      then
-          return 'y';
-      else 
-          return 'n';
-      end if;
-  end;*/
 
   function next_multistep_exists 
   ( p_process_id in flow_processes.prcs_id%type
@@ -295,64 +219,12 @@ as
       return null;
   end next_step_type;
 
-function get_current_progress -- creates the markings for the bpmn viewer to show current progress
-( p_process_id in flow_processes.prcs_id%type
-) return varchar2
-is 
-    l_marker_json varchar2(2000);
-begin
-    apex_debug.message(p_message => 'Begin get_current_progress', p_level => 3) ;
-    WITH markings AS 
-    (
-    select 
-          sflg.sflg_objt_id bpmnObject
-         ,'completed-node-bpmn' marking
-         ,'1' layer
-      from flow_subflow_log sflg 
-     where sflg.sflg_prcs_id = p_process_id
-    UNION
-    select distinct 
-          sbfl.sbfl_last_completed bpmnObject 
-        ,'last-completed-node-bpmn'  marking
-        , '2' layer
-     from flow_subflows sbfl
-    where sbfl.sbfl_last_completed is not null
-      and sbfl.sbfl_prcs_id = p_process_id
-    UNION
-    select distinct 
-          sbfl.sbfl_current bpmnObject 
-        ,'current-node-bpmn'  marking
-        , '3' layer
-     from flow_subflows sbfl
-    where sbfl.sbfl_current is not null
-      and sbfl.sbfl_prcs_id = p_process_id
-    )
-    select JSON_ARRAYAGG
-            ( JSON_OBJECT
-                ( KEY 'bpmnObject' VALUE m.bpmnObject
-                , KEY 'marking' VALUE m.marking
-                ) order by m.layer asc
-            )
-      into l_marker_json  
-      from markings m
-    ;
-    return l_marker_json;
-exception
-  when others
-  then
-    raise;
-end get_current_progress;
-
-
 procedure flow_start
   ( p_process_id in flow_processes.prcs_id%type
   )
   is
-    l_dgrm_id         flow_diagrams.dgrm_id%type;
     l_process_status  flow_processes.prcs_status%type;
-  begin
-      l_dgrm_id := get_dgrm_id( p_prcs_id => p_process_id );
-    
+  begin  
       apex_debug.message(p_message => 'Begin flow_start', p_level => 3) ;
       -- check the process isn't already running and return error if it is
       begin

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -74,16 +74,6 @@ as
 **        APPLICATION HELPERS (Progress, Next Step needs Decisions, etc.)
 **
 ********************************************************************************/ 
-  /*
-  function next_step_exists
-  ( p_process_id in flow_processes.prcs_id%type
-  , p_subflow_id in flow_subflows.sbfl_id%type
-  ) return boolean;
-
-  function next_step_exists_yn
-  ( p_process_id in flow_processes.prcs_id%type
-  , p_subflow_id in flow_subflows.sbfl_id%type
-  ) return varchar2; */
 
   function next_multistep_exists
   ( p_process_id in flow_processes.prcs_id%type
@@ -99,12 +89,6 @@ as
   (
     p_sbfl_id in flow_subflows.sbfl_id%type
   ) return varchar2;
-
-  function get_current_progress -- creates the markings for the bpmn viewer to show current progress 
-  ( 
-    p_process_id in flow_processes.prcs_id%type 
-  ) return varchar2;
-
 
 end flow_api_pkg;
 /

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -1614,6 +1614,11 @@ begin
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
     ;
+    -- set boundaryEvent Timers, if any
+    flow_set_boundary_timers 
+    ( p_process_id => p_process_id
+    , p_subflow_id => p_subflow_id
+    );  
 end process_userTask;
 
 procedure process_scriptTask
@@ -1692,6 +1697,11 @@ begin
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
     ;
+    -- set boundaryEvent Timers, if any
+    flow_set_boundary_timers 
+    ( p_process_id => p_process_id
+    , p_subflow_id => p_subflow_id
+    );  
 end process_manualTask;
 
 /* 
@@ -1919,7 +1929,11 @@ begin
           p_process_id => p_process_id
         , p_subflow_id => p_subflow_id
         );
-    elsif l_curr_objt_tag_name in ( 'bpmn:subProcess', 'bpmn:task' )   -- add activities into here later
+    elsif l_curr_objt_tag_name in ( 'bpmn:subProcess'
+                                  , 'bpmn:task' 
+                                  , 'bpmn:userTask'
+                                  , 'bpmn:manualTask'
+                                  )   -- add any objects that can support timer boundary events here
     then
         handle_interrupting_boundary_event 
         ( p_process_id => p_process_id
@@ -2045,7 +2059,11 @@ begin
     );
   end;
   -- clean up any boundary events left over from the previous activity
-  if (l_step_info.source_objt_tag in ('bpmn:subProcess', 'bpmn:task')      -- boundary event attachable types
+  if (l_step_info.source_objt_tag in ( 'bpmn:subProcess'
+                                     , 'bpmn:task'
+                                     , 'bpmn:userTask'
+                                     , 'bpmn:manualTask'
+                                    ) -- boundary event attachable types
       and l_sbfl_rec.sbfl_has_events is not null )            -- subflow has events attached
   then
       -- 

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -1,6 +1,15 @@
 create or replace package body flow_engine
 as 
 
+type flow_step_info is record
+( dgrm_id           flow_diagrams.dgrm_id%type
+, source_objt_tag   flow_objects.objt_tag_name%type
+, target_objt_id    flow_objects.objt_id%type
+, target_objt_ref   flow_objects.objt_bpmn_id%type
+, target_objt_tag   flow_objects.objt_tag_name%type
+, target_objt_subtag flow_objects.objt_sub_tag_name%type
+);
+
 function get_dgrm_id
   (
     p_prcs_id in flow_processes.prcs_id%type
@@ -2189,6 +2198,37 @@ end flow_next_step;
 ****                       PROCESS INSTANCE FUNCTIONS (START, STOP, RESET, DELETE)
 ****
 *************************************************************************************************************/
+
+function flow_create
+  ( p_dgrm_id   in flow_diagrams.dgrm_id%type
+  , p_prcs_name in flow_processes.prcs_name%type default null
+  ) return flow_processes.prcs_id%type
+is
+    l_ret flow_processes.prcs_id%type;
+begin
+    apex_debug.message(p_message => 'Begin flow_create', p_level => 3) ;
+    insert 
+      into  flow_processes prcs
+          ( prcs.prcs_name
+          , prcs.prcs_dgrm_id
+          , prcs.prcs_status
+          , prcs.prcs_init_ts
+          , prcs.prcs_last_update
+          )
+    values
+          ( p_prcs_name
+          , p_dgrm_id
+          , 'created'
+          , systimestamp
+          , systimestamp
+          )
+      returning prcs.prcs_id into l_ret
+    ;
+    apex_debug.message(p_message => 'End flow_create', p_level => 3) ;
+
+    return l_ret;
+end flow_create;
+
 
 procedure flow_reset
   ( p_process_id in flow_processes.prcs_id%type

--- a/src/plsql/flow_engine.pks
+++ b/src/plsql/flow_engine.pks
@@ -2,29 +2,25 @@ create or replace package flow_engine
 accessible by (flow_api_pkg, flow_timers_pkg)
 as 
 
-type flow_step_info is record
-( dgrm_id           flow_diagrams.dgrm_id%type
-, source_objt_tag   flow_objects.objt_tag_name%type
-, target_objt_id    flow_objects.objt_id%type
-, target_objt_ref   flow_objects.objt_bpmn_id%type
-, target_objt_tag   flow_objects.objt_tag_name%type
-, target_objt_subtag flow_objects.objt_sub_tag_name%type
-);
-
 procedure flow_handle_event
   ( p_process_id    in flow_processes.prcs_id%type
   , p_subflow_id    in flow_subflows.sbfl_id%type
   ); 
 
+function flow_create
+  ( p_dgrm_id   in flow_diagrams.dgrm_id%type
+  , p_prcs_name in flow_processes.prcs_name%type default null
+  ) return flow_processes.prcs_id%type;
+
 procedure flow_start_process
-    ( p_process_id    in flow_processes.prcs_id%type
-    );
+  ( p_process_id    in flow_processes.prcs_id%type
+  );
 
 procedure flow_next_step
-( p_process_id    in flow_processes.prcs_id%type
-, p_subflow_id    in flow_subflows.sbfl_id%type
-, p_forward_route in flow_connections.conn_bpmn_id%type default null   
-);
+  ( p_process_id    in flow_processes.prcs_id%type
+  , p_subflow_id    in flow_subflows.sbfl_id%type
+  , p_forward_route in flow_connections.conn_bpmn_id%type default null   
+  );
 
 procedure flow_reset
   ( p_process_id in flow_processes.prcs_id%type


### PR DESCRIPTION
- #37 - flow_api_pkg - flow_create implementation moved to flow_engine.  Overloads remain in flow_api_pkg
- flow_engine record definitions moved from package spec to body
- some V4 helper procedures deleted from flow_api_pkg
- flow_next_step(p_forward_route) parameter no longer passable from flow_api_pkg (as was always intended)
- timer boundary events now enabled for bpmn:userTask and bpmn:manualTask objects
- other minor tidy up