### PR TITLE
Fixes Issue #91

### DIFF
--- a/src/plsql/flow_bpmn_parser_pkg.pkb
+++ b/src/plsql/flow_bpmn_parser_pkg.pkb
@@ -581,8 +581,8 @@ as
       l_return := flow_constants_pkg.gc_timer_type_duration;
     elsif pi_xml.existsNode( xpath => '/' || flow_constants_pkg.gc_timer_type_cycle, nsmap => c_nsmap ) = 1 then
       l_return := flow_constants_pkg.gc_timer_type_cycle;
-    elsif pi_xml.existsNode( xpath => '/' || flow_constants_pkg.gc_bpmn_error_event_definitition, nsmap => c_nsmap ) = 1 then
-      l_return := flow_constants_pkg.gc_bpmn_error_event_definitition;
+    elsif pi_xml.existsNode( xpath => '/' || flow_constants_pkg.gc_bpmn_error_event_definition, nsmap => c_nsmap ) = 1 then
+      l_return := flow_constants_pkg.gc_bpmn_error_event_definition;
     elsif pi_xml.existsNode( xpath => '/' || flow_constants_pkg.gc_bpmn_escalation_event_definition, nsmap => c_nsmap ) = 1 then
       l_return := flow_constants_pkg.gc_bpmn_escalation_event_definition;
     elsif pi_xml.existsNode( xpath => '/' || flow_constants_pkg.gc_bpmn_link_event_definition, nsmap => c_nsmap ) = 1 then

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -12,8 +12,17 @@ as
   gc_apex_prefix constant varchar2(10 char)  := 'apex:';
 
   -- BPMN Keys
+  gc_bpmn_process                     constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'process';
+  gc_bpmn_subprocess                  constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'subProcess';
+
+  gc_bpmn_start_event                 constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'startEvent';
+  gc_bpmn_end_event                   constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'endEvent';
+  gc_bpmn_intermediate_throw_event    constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'intermediateThrowEvent';
+  gc_bpmn_intermediate_catch_event    constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'intermediateCatchEvent';
+  gc_bpmn_boundary_event              constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'boundaryEvent';
+
   gc_bpmn_terminate_event_definition  constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'terminateEventDefinition';
-  gc_bpmn_error_event_definitition    constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'errorEventDefinition';
+  gc_bpmn_error_event_definition      constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'errorEventDefinition';
   gc_bpmn_escalation_event_definition constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'escalationEventDefinition';
   gc_bpmn_link_event_definition       constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'linkEventDefinition';
 
@@ -26,8 +35,16 @@ as
 
   gc_bpmn_gateway_exclusive           constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'exclusiveGateway';
   gc_bpmn_gateway_inclusive           constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'inclusiveGateway';
+  gc_bpmn_gateway_parallel            constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'parallelGateway';
+  gc_bpmn_gateway_event_based         constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'eventBasedGateway';
+
   gc_bpmn_sequence_flow               constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'sequenceFlow';
+
+  gc_bpmn_task                        constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'task';
   gc_bpmn_usertask                    constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'userTask';
+  gc_bpmn_servicetask                 constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'serviceTask';
+  gc_bpmn_manualtask                  constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'manualTask';
+  gc_bpmn_scripttask                  constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'scriptTask';
 
   -- APEX Extensions to BPMN
   -- userTask
@@ -63,6 +80,16 @@ as
   gc_dgrm_status_released             constant  varchar2(10 char) := 'released';
   gc_dgrm_status_deprecated           constant  varchar2(10 char) := 'deprecated';
   gc_dgrm_status_archived             constant  varchar2(10 char) := 'archived';
+
+  -- Subflow status
+  gc_sbfl_status_running              constant  varchar2(20 char) := 'running';
+  gc_sbfl_status_waiting_timer        constant  varchar2(20 char) := 'waiting for timer';
+  gc_sbfl_status_waiting_gateway      constant  varchar2(20 char) := 'waiting at gateway';
+  gc_sbfl_status_waiting_event        constant  varchar2(20 char) := 'waiting for event';
+  gc_sbfl_status_proceed_gateway      constant  varchar2(20 char) := 'proceed from gateway';
+  gc_sbfl_status_split                constant  varchar2(20 char) := 'split';
+  gc_sbfl_status_in_subprocess        constant  varchar2(20 char) := 'in subprocess';
+
 
 end flow_constants_pkg;
 /

--- a/src/plsql/flow_timers_pkg.pkb
+++ b/src/plsql/flow_timers_pkg.pkb
@@ -24,7 +24,7 @@ as
          and objt.objt_dgrm_id = prcs.prcs_dgrm_id
        where sbfl.sbfl_id = pi_sbfl_id
          and sbfl.sbfl_prcs_id = pi_prcs_id
-         and objt.objt_sub_tag_name = 'bpmn:timerEventDefinition'
+         and objt.objt_sub_tag_name = flow_constants_pkg.gc_bpmn_timer_event_definition
       ;
     exception
       when no_data_found then
@@ -43,7 +43,7 @@ as
              and boundary_objt.objt_dgrm_id = prcs.prcs_dgrm_id
            where sbfl.sbfl_id = pi_sbfl_id
              and prcs.prcs_id = pi_prcs_id
-             and boundary_objt.objt_sub_tag_name = 'bpmn:timerEventDefinition'
+             and boundary_objt.objt_sub_tag_name = flow_constants_pkg.gc_bpmn_timer_event_definition
              and boundary_objt.objt_interrupting = 1
           ;
         exception


### PR DESCRIPTION
Nested, Open (i.e., not ending in a matching closing / merging gateway) Inclusive or Parallel Gateway Section left a subflow behind at the end of the process.
The existing subflow_complete routine did cleanup, looking for orphan subflows after all of the parallel paths of a parallel section have completed at their own end events.  I hadn't anticipated that open parallel sections would be nested inside another open parallel section -- and so cleanup was only 1 level deep.  subflow_complete is now called recursively & so cleanup will now work however deep these unclosed sections are nested.