### PR TITLE
all subflow updates now use systimestamp

### DIFF
--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -727,7 +727,7 @@ begin
     update flow_subflows sbfl
     set   sbfl.sbfl_current = l_next_objt
         , sbfl.sbfl_last_completed = p_step_info.target_objt_ref
-        , sbfl.sbfl_last_update = sysdate
+        , sbfl.sbfl_last_update = systimestamp
         , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
     where sbfl.sbfl_id = p_subflow_id
         and sbfl.sbfl_prcs_id = p_process_id
@@ -895,7 +895,7 @@ begin
         update flow_subflows sbfl
         set   sbfl.sbfl_current = p_step_info.target_objt_ref
             , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-            , sbfl.sbfl_last_update = sysdate
+            , sbfl.sbfl_last_update = systimestamp
             , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
         where sbfl.sbfl_id = p_subflow_id
           and sbfl.sbfl_prcs_id = p_process_id
@@ -1103,7 +1103,7 @@ end process_endEvent;
       -- set current subflow to status waiting,       
       update flow_subflows sbfl
          set sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_waiting_gateway
-           , sbfl.sbfl_last_update = sysdate 
+           , sbfl.sbfl_last_update = systimestamp 
            , sbfl.sbfl_current = p_step_info.target_objt_ref
        where sbfl.sbfl_id = p_subflow_id
          and sbfl.sbfl_prcs_id = p_process_id
@@ -1143,7 +1143,7 @@ end process_endEvent;
         update flow_subflows sbfl
            set sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_proceed_gateway
              , sbfl.sbfl_current = p_step_info.target_objt_ref
-             , sbfl.sbfl_last_update = sysdate
+             , sbfl.sbfl_last_update = systimestamp
          where sbfl.sbfl_last_completed = p_sbfl_info.sbfl_starting_object
            and sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
            and sbfl.sbfl_id = p_sbfl_info.sbfl_sbfl_id
@@ -1160,7 +1160,7 @@ end process_endEvent;
            set sbfl.sbfl_last_completed = p_step_info.target_objt_ref
              , sbfl.sbfl_current = null
              , sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
-             , sbfl.sbfl_last_update = sysdate 
+             , sbfl.sbfl_last_update = systimestamp 
          where sbfl.sbfl_id = l_sbfl_id
            and sbfl.sbfl_prcs_id = p_process_id
         ;
@@ -1212,7 +1212,7 @@ end process_endEvent;
             set sbfl.sbfl_last_completed = p_step_info.target_objt_ref
               , sbfl.sbfl_current = p_step_info.target_objt_ref
               , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
-              , sbfl.sbfl_last_update = sysdate 
+              , sbfl.sbfl_last_update = systimestamp 
           where sbfl.sbfl_id = l_sbfl_id
             and sbfl.sbfl_prcs_id = p_process_id
         ;
@@ -1263,7 +1263,7 @@ end process_endEvent;
          set sbfl.sbfl_last_completed = p_step_info.target_objt_ref
            , sbfl.sbfl_current = ''
            , sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
-           , sbfl.sbfl_last_update = sysdate 
+           , sbfl.sbfl_last_update = systimestamp 
        where sbfl.sbfl_id = p_subflow_id
          and sbfl.sbfl_prcs_id = p_process_id
       ;
@@ -1323,7 +1323,7 @@ end process_endEvent;
       -- set current subflow to status waiting,       
       update flow_subflows sbfl
          set sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_waiting_gateway
-           , sbfl.sbfl_last_update = sysdate 
+           , sbfl.sbfl_last_update = systimestamp 
            , sbfl.sbfl_current = p_step_info.target_objt_ref
        where sbfl.sbfl_id = p_subflow_id
          and sbfl.sbfl_prcs_id = p_process_id
@@ -1360,7 +1360,7 @@ end process_endEvent;
           set sbfl.sbfl_last_completed = p_step_info.target_objt_ref
             , sbfl.sbfl_current = p_step_info.target_objt_ref
             , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
-            , sbfl.sbfl_last_update = sysdate
+            , sbfl.sbfl_last_update = systimestamp
         where sbfl.sbfl_last_completed = p_sbfl_info.sbfl_starting_object
           and sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
           and sbfl.sbfl_id = p_sbfl_info.sbfl_sbfl_id
@@ -1405,7 +1405,7 @@ begin
     update flow_subflows sbfl
         set sbfl.sbfl_current = p_step_info.target_objt_ref
             , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-            , sbfl.sbfl_last_update = sysdate
+            , sbfl.sbfl_last_update = systimestamp
             , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
       where sbfl.sbfl_id = p_subflow_id
         and sbfl.sbfl_prcs_id = p_process_id
@@ -1470,7 +1470,7 @@ end process_exclusiveGateway;
     update flow_subflows sbfl
     set   sbfl.sbfl_current = p_step_info.target_objt_ref -- parent subProc Activity
         , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-        , sbfl.sbfl_last_update = sysdate
+        , sbfl.sbfl_last_update = systimestamp
         , sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_in_subprocess
     where sbfl.sbfl_id = p_subflow_id
       and sbfl.sbfl_prcs_id = p_process_id
@@ -1513,7 +1513,7 @@ end process_exclusiveGateway;
        set sbfl.sbfl_last_completed = p_step_info.target_objt_ref
          , sbfl.sbfl_current = p_step_info.target_objt_ref
          , sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
-         , sbfl.sbfl_last_update = sysdate 
+         , sbfl.sbfl_last_update = systimestamp 
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
     ;
@@ -1578,7 +1578,7 @@ end process_exclusiveGateway;
       update flow_subflows sbfl
          set sbfl.sbfl_current = p_step_info.target_objt_ref
            , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-           , sbfl.sbfl_last_update = sysdate
+           , sbfl.sbfl_last_update = systimestamp
            , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_waiting_timer
        where sbfl.sbfl_id = p_subflow_id
          and sbfl.sbfl_prcs_id = p_process_id
@@ -1594,7 +1594,7 @@ end process_exclusiveGateway;
       update flow_subflows sbfl
          set sbfl.sbfl_current = p_step_info.target_objt_ref
            , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-           , sbfl.sbfl_last_update = sysdate
+           , sbfl.sbfl_last_update = systimestamp
            , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
        where sbfl.sbfl_id = p_subflow_id
          and sbfl.sbfl_prcs_id = p_process_id
@@ -1622,7 +1622,7 @@ end process_exclusiveGateway;
         update flow_subflows sbfl
         set   sbfl.sbfl_current = p_step_info.target_objt_ref
             , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-            , sbfl.sbfl_last_update = sysdate
+            , sbfl.sbfl_last_update = systimestamp
             , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
         where sbfl.sbfl_id = p_subflow_id
             and sbfl.sbfl_prcs_id = p_process_id
@@ -1644,7 +1644,7 @@ end process_exclusiveGateway;
         update flow_subflows sbfl
            set sbfl.sbfl_current = p_step_info.target_objt_ref
              , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_current
-             , sbfl.sbfl_last_update = sysdate
+             , sbfl.sbfl_last_update = systimestamp
              , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
          where sbfl.sbfl_id = p_subflow_id
            and sbfl.sbfl_prcs_id = p_process_id
@@ -1686,7 +1686,7 @@ begin
     update flow_subflows sbfl
     set   sbfl.sbfl_current = p_step_info.target_objt_ref
          , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-         , sbfl.sbfl_last_update = sysdate
+         , sbfl.sbfl_last_update = systimestamp
          , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
@@ -1718,7 +1718,7 @@ end process_userTask;
     update flow_subflows sbfl
      set   sbfl.sbfl_current = p_step_info.target_objt_ref
          , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-         , sbfl.sbfl_last_update = sysdate
+         , sbfl.sbfl_last_update = systimestamp
          , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
@@ -1756,7 +1756,7 @@ end process_userTask;
     update flow_subflows sbfl
     set   sbfl.sbfl_current = p_step_info.target_objt_ref
         , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-        , sbfl.sbfl_last_update = sysdate
+        , sbfl.sbfl_last_update = systimestamp
         , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
     where sbfl.sbfl_id = p_subflow_id
         and sbfl.sbfl_prcs_id = p_process_id
@@ -1792,7 +1792,7 @@ end process_userTask;
     update flow_subflows sbfl
      set   sbfl.sbfl_current = p_step_info.target_objt_ref
          , sbfl.sbfl_last_completed = p_sbfl_info.sbfl_last_completed
-         , sbfl.sbfl_last_update = sysdate
+         , sbfl.sbfl_last_update = systimestamp
          , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
      where sbfl.sbfl_id = p_subflow_id
        and sbfl.sbfl_prcs_id = p_process_id
@@ -1871,7 +1871,7 @@ begin
      update flow_subflows sbfl
         set sbfl_status = flow_constants_pkg.gc_sbfl_status_running
           , sbfl_current = l_current_object
-          , sbfl_last_update = sysdate
+          , sbfl_last_update = systimestamp
       where sbfl.sbfl_prcs_id = p_process_id
         and sbfl.sbfl_id = p_parent_subflow_id
         and sbfl.sbfl_status =  flow_constants_pkg.gc_sbfl_status_split  
@@ -1928,7 +1928,7 @@ begin
       apex_debug.message(p_message => 'Begin handle_intermediate_catch_event', p_level => 3) ;
       update flow_subflows sbfl 
          set sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
-           , sbfl.sbfl_last_update = sysdate
+           , sbfl.sbfl_last_update = systimestamp
        where sbfl.sbfl_prcs_id = p_process_id
          and sbfl.sbfl_id = p_subflow_id
            ;
@@ -1993,7 +1993,7 @@ begin
        set sbfl.sbfl_current = l_boundary_objt_bpmn_id
          , sbfl.sbfl_status = flow_constants_pkg.gc_sbfl_status_running
          , sbfl.sbfl_last_completed = l_parent_objt_bpmn_id
-         , sbfl.sbfl_last_update = sysdate 
+         , sbfl.sbfl_last_update = systimestamp 
      where sbfl.sbfl_id = p_subflow_id 
        and sbfl.sbfl_prcs_id = p_process_id
          ;


### PR DESCRIPTION
Fixes #180 - all flow_subflow updates now use systimestamp, not sysdate