### PR TITLE
fixes issue #101 - rem v4 syntax from API + views

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Flows for APEX - Changelog
 
+## v21.1
+
+- NOTE - MAJOR NEW FEATURES then MINOR CHANGES then DEPRECATION then REMOVAL...
+- Removed - v4 API calls flow_next_step, flow_next_branch, next_multistep_exists, next_multistep_exists_yn, next_step_type (all non-functioning in v5) removed.
+- Removed - Column sbfl_next_step_type removed from flow_subflows_vw, flow_task_inbox_vw, and application views based on them. (no longer functional v4 feature).
+
 ## v5.1.2
 
 - Added business reference to views

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -1,17 +1,10 @@
 create or replace package flow_api_pkg
 as
 
-  gc_step          constant varchar2(50 char) := 'simple-step';
-  gc_single_choice constant varchar2(50 char) := 'single-choice';
-  gc_multi_choice  constant varchar2(50 char) := 'multi-choice';
-
-  pragma deprecate (gc_step ,'gc_step not required in v5.  Will be removed in v21');
-  pragma deprecate (gc_single_choice ,'gc_single_choice not required in v5.  Will be removed in v21');
-  pragma deprecate (gc_multi_choice ,'gc_multi_choice not required in v5.  Will be removed in v21');
-
 /********************************************************************************
 **
-**        FLOW OPERATIONS (Create, Start, Next_step, Reset, Stop, Delete)
+**        FLOW INSTANCE OPERATIONS (Create, Start, Reset, Terminate, Delete)
+**        STEP OPERATIONS (Reserve, Release, Complete)
 **
 ********************************************************************************/
 
@@ -164,71 +157,6 @@ flow_delete ends all processing of a process instance.  It removes all subflows 
     p_process_id in flow_processes.prcs_id%type
   , p_subflow_id in flow_subflows.sbfl_id%type
   ) return varchar2;
-
- /********************************************************************************
-**
-**        DEPRECATED API CALLS - 
-**
-********************************************************************************/ 
-  -- flow_next_branch.  
-  -- Deprecated in V5.0.  Returns an Error Message in V5.0.  
-  -- To be Removed in V6.0
-  -- Note: flow_next_branch no longer required or supported in V5.0.  Flow_complete_step is used 
-  -- to advance the process through gateways as well as task objects.
-  procedure flow_next_branch
-  ( p_process_id  in flow_processes.prcs_id%type
-  , p_subflow_id  in flow_subflows.sbfl_id%type
-  , p_branch_name in varchar2
-  );
-  pragma deprecate (flow_next_branch,'Flow_next_branch not required in v5.  Will be removed in v21');
-
-  -- flow_next_step
-  -- Deprecated in V5.0.  Returns an Error Message in V5.0.  
-  -- To be Removed in V6.0
-  -- Note: In V5.0, flow_next_step calls flow_complete_step.  See doc.
-  -- A Forward Route should also not be specified and will return an error message in V5.0+
-  procedure flow_next_step
-  (
-    p_process_id    in flow_processes.prcs_id%type
-  , p_subflow_id    in flow_subflows.sbfl_id%type
-  , p_forward_route in varchar2 default null
-  );
-
-  pragma deprecate (flow_next_step,'Flow_next_step replaced by flow_complete_step in v5.  Will be removed in v21');
- /********************************************************************************
-**
-**        DEPRECATED APPLICATION HELPERS (Progress, Next Step needs Decisions, etc.)
-**
-********************************************************************************/ 
- 
- -- used to handle gateway objects when the app had to decide whether to call flow_next_step
- -- or flow_next_branch.  No longer required in V5.0 and later.  
- -- To be deleted in v6.0
-  function next_multistep_exists
-  ( p_process_id in flow_processes.prcs_id%type
-  , p_subflow_id in flow_subflows.sbfl_id%type
-  ) return boolean;
-
-  pragma deprecate (next_multistep_exists,'next_multistep_exists not required in v5.  Will be removed in v21');
- -- used to handle gateway objects when the app had to decide whether to call flow_next_step
- -- or flow_next_branch.  No longer required in V5.0 and later.  
- -- To be deleted in v6.0
-  function next_multistep_exists_yn
-  ( p_process_id in flow_processes.prcs_id%type
-  , p_subflow_id in flow_subflows.sbfl_id%type
-  ) return varchar2;
-
-  pragma deprecate (next_multistep_exists_yn,'next_multistep_exists_yn not required in v5.  Will be removed in v21');
- -- used to handle gateway objects when the app had to decide whether to call flow_next_step
- -- or flow_next_branch.  No longer required in V5.0 and later.  
- -- in V5.x, always returns 'simple-step'
- -- To be deleted in v6.0
-  function next_step_type
-  (
-    p_sbfl_id in flow_subflows.sbfl_id%type
-  ) return varchar2;
-
-    pragma deprecate (next_step_type,'next_step_type not required in v5.  Will be removed in v21');
 
 end flow_api_pkg;
 /

--- a/src/views/engine-app/flow_p0010_subflows_debug_vw.sql
+++ b/src/views/engine-app/flow_p0010_subflows_debug_vw.sql
@@ -26,7 +26,6 @@ as
        , sbfl.sbfl_current_lane
        , sbfl.sbfl_current_lane_name
        , sbfl.sbfl_reservation
-       , sbfl.sbfl_next_step_type
        , sbfl.sbfl_process_level
        , case
           when sbfl.sbfl_status in ('split', 'in subprocess', 'waiting at gateway', 'waiting for event', 'waiting for timer') then
@@ -41,19 +40,9 @@ as
             '"></span>'
           else
             '<button type="button" class="clickable-action t-Button t-Button--noLabel t-Button--icon" ' ||
-            case 
-              when sbfl.sbfl_next_step_type in ( 'single-choice', 'multi-choice' ) then 'title="Choose branch" aria-label="Choose branch" '
-              when sbfl.sbfl_next_step_type = 'simple-step' then 'title="Go to next step" aria-label="Go to next step" '
-            end || 'data-prcs="' || sbfl.sbfl_prcs_id || '" data-sbfl="' || sbfl.sbfl_id || '" data-action="' ||
-            case sbfl.sbfl_next_step_type
-              when 'single-choice' then 'choose_single'
-              when 'multi-choice' then 'choose_multiple'
-              when 'simple-step' then 'next_step'
-            end || '"><span aria-hidden="true" class="' ||
-            case
-              when sbfl.sbfl_next_step_type in ( 'single-choice', 'multi-choice' ) then 'fa fa-tasks'
-              when sbfl.sbfl_next_step_type = 'simple-step' then 'fa fa-sign-out'
-            end || '"></span></button>'
+            'title="Go to next step" aria-label="Go to next step" ' ||
+            'data-prcs="' || sbfl.sbfl_prcs_id || '" data-sbfl="' || sbfl.sbfl_id || 
+            '" data-action="next_step"><span aria-hidden="true" class="fa fa-sign-out"></span></button>' 
          end as action_html
        , case 
           when sbfl.sbfl_status = 'running' then 

--- a/src/views/engine-app/flow_p0010_subflows_vw.sql
+++ b/src/views/engine-app/flow_p0010_subflows_vw.sql
@@ -21,19 +21,9 @@ as
             '"></span>'
           else
             '<button type="button" class="clickable-action t-Button t-Button--noLabel t-Button--icon" ' ||
-            case 
-              when sbfl.sbfl_next_step_type in ( 'single-choice', 'multi-choice' ) then 'title="Choose branch" aria-label="Choose branch" '
-              when sbfl.sbfl_next_step_type = 'simple-step' then 'title="Go to next step" aria-label="Go to next step" '
-            end || 'data-prcs="' || sbfl.sbfl_prcs_id || '" data-sbfl="' || sbfl.sbfl_id || '" data-action="' ||
-            case sbfl.sbfl_next_step_type
-              when 'single-choice' then 'choose_single'
-              when 'multi-choice' then 'choose_multiple'
-              when 'simple-step' then 'next_step'
-            end || '"><span aria-hidden="true" class="' ||
-            case
-              when sbfl.sbfl_next_step_type in ( 'single-choice', 'multi-choice' ) then 'fa fa-tasks'
-              when sbfl.sbfl_next_step_type = 'simple-step' then 'fa fa-sign-out'
-            end || '"></span></button>'
+            'title="Go to next step" aria-label="Go to next step" ' ||
+            'data-prcs="' || sbfl.sbfl_prcs_id || '" data-sbfl="' || sbfl.sbfl_id || 
+            '" data-action="next_step"><span aria-hidden="true" class="fa fa-sign-out"></span></button>' 
          end as action_html
        , case 
           when sbfl.sbfl_status = 'running' then 

--- a/src/views/flow_subflows_vw.sql
+++ b/src/views/flow_subflows_vw.sql
@@ -21,7 +21,6 @@ as
         , objt_curr.objt_tag_name as sbfl_current_tag_name
         , sbfl.sbfl_last_update
         , sbfl.sbfl_status
-        , 'simple-step' as sbfl_next_step_type -- FOR V4 Compatibility.  will be removed in V6
         , lane.objt_bpmn_id as sbfl_current_lane
         , coalesce( lane.objt_name, lane.objt_bpmn_id) as sbfl_current_lane_name
         , sbfl.sbfl_process_level

--- a/src/views/flow_task_inbox_vw.sql
+++ b/src/views/flow_task_inbox_vw.sql
@@ -31,7 +31,6 @@ as
         , sbfl_current_tag_name
         , sbfl_last_update
         , sbfl_status
-        , sbfl_next_step_type
         , sbfl_current_lane
         , sbfl_current_lane_name
         , sbfl_reservation


### PR DESCRIPTION
Fixes issue #101 

- removed old v4 API calls flow_next_step, flow_next_branch, multistep exists, etc.
- removes sbfl_next_step_type from subflow views

All of these were non functional in V5 & don't affect the Flows for APEX app.