### PR TITLE
adds flow_globals.process_id #268

### DIFF
--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -151,10 +151,14 @@ as
     is
     begin  
         apex_debug.message(p_message => 'Begin flow_start', p_level => 3) ;
+
+        flow_globals.set_context
+        ( pi_prcs_id => p_process_id
+        );
   
         flow_instances.start_process 
-          ( p_process_id => p_process_id
-          );
+        ( p_process_id => p_process_id
+        );
   end flow_start;
 
   procedure flow_reserve_step
@@ -206,6 +210,10 @@ as
   )
   is 
   begin 
+    flow_globals.set_context
+    ( pi_prcs_id => p_process_id
+    , pi_sbfl_id => p_subflow_id
+    );
     flow_engine.restart_step
     ( p_process_id => p_process_id
     , p_subflow_id => p_subflow_id
@@ -220,7 +228,10 @@ as
   )
   is 
   begin
-
+    flow_globals.set_context
+    ( pi_prcs_id => p_process_id
+    , pi_sbfl_id => p_subflow_id
+    );
     flow_engine.flow_complete_step
     ( p_process_id => p_process_id
     , p_subflow_id => p_subflow_id

--- a/src/plsql/flow_globals.pkb
+++ b/src/plsql/flow_globals.pkb
@@ -1,0 +1,16 @@
+create or replace package body flow_globals
+as
+
+  procedure set_context
+  ( pi_prcs_id in flow_processes.prcs_id%type
+  , pi_sbfl_id in flow_subflows.sbfl_id%type default null
+  )
+  is
+  begin 
+    process_id := pi_prcs_id;
+    subflow_id := pi_sbfl_id;
+  
+  end set_context;
+
+end flow_globals;
+/

--- a/src/plsql/flow_globals.pks
+++ b/src/plsql/flow_globals.pks
@@ -1,0 +1,13 @@
+create or replace package flow_globals
+as
+
+  process_id flow_processes.prcs_id%type;
+  subflow_id flow_subflows.sbfl_id%type;
+
+  procedure set_context
+  ( pi_prcs_id in flow_processes.prcs_id%type
+  , pi_sbfl_id in flow_subflows.sbfl_id%type default null
+  );
+
+end flow_globals;
+/


### PR DESCRIPTION
- adds flow_globals package to provide process_id and subflow_id for scripts and variable expressions.
- note that process_IS should be correct in this commit, but subflow_id is not reliable if the model changes to another subflow in the current step.  (I've pushed this before finishing & testing for Nie;ld demo that needs just process_id!).
- please LEAVE branch after merge