### PR TITLE
provides flow_globals.process_id and subflow_id

### DIFF
--- a/src/install_db_scratch.sql
+++ b/src/install_db_scratch.sql
@@ -27,6 +27,8 @@ PROMPT >> Installing Package Specifications
 @plsql/flow_usertask_pkg.pks
 @plsql/flow_plsql_runner_pkg.pks
 @plsql/flow_logging.pks
+@plsql/flow_globals.pks
+
 
 PROMPT >> Installing Views
 @views/flow_instances_vw.sql
@@ -57,6 +59,8 @@ PROMPT >> Installing Package Bodies
 @plsql/flow_usertask_pkg.pkb
 @plsql/flow_plsql_runner_pkg.pkb
 @plsql/flow_logging.pkb
+@plsql/flow_globals.pkb
+
 
 PROMPT >> Installing Engine-App Objects
 PROMPT >> =============================

--- a/src/migrate_db.sql
+++ b/src/migrate_db.sql
@@ -30,6 +30,7 @@ PROMPT >> Installing Package Specifications
 @plsql/flow_usertask_pkg.pks
 @plsql/flow_plsql_runner_pkg.pks
 @plsql/flow_logging.pks
+@plsql/flow_globals.pks
 
 
 PROMPT >> Installing Views
@@ -61,6 +62,8 @@ PROMPT >> Installing Package Bodies
 @plsql/flow_usertask_pkg.pkb
 @plsql/flow_plsql_runner_pkg.pkb
 @plsql/flow_logging.pkb
+@plsql/flow_globals.pkb
+
 
 
 PROMPT >> Installing Engine-App Objects

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -668,6 +668,7 @@ is
   l_dgrm_id               flow_diagrams.dgrm_id%type;
   l_sbfl_current          flow_subflows.sbfl_current%type;
 begin
+  -- currently handles callbacks from flow_timers when a timer fires
   apex_debug.enter 
   ( 'flow_handle_event'
   , 'Subflow', p_subflow_id
@@ -678,7 +679,11 @@ begin
   -- an independant iCE (not following an eBG) can have >1 inputs
   -- so look for preceding eBG.  If previous event not eBG or there are multiple prev events, it did not follow an eBG.
   l_dgrm_id := flow_engine_util.get_dgrm_id (p_prcs_id => p_process_id);
-
+  -- set context for scripts and variable expressions
+  flow_globals.set_context
+  ( pi_prcs_id => p_process_id
+  , pi_sbfl_id => p_subflow_id
+  );
   -- lock subflow containing event
   if flow_engine_util.lock_subflow(p_subflow_id) then
     -- subflow_locked

--- a/src/plsql/flow_expressions.pkb
+++ b/src/plsql/flow_expressions.pkb
@@ -531,50 +531,56 @@ as
     ( pi_objt_id => pi_objt_id
     , pi_set     => pi_set
     );
-    apex_debug.trace 
-    ( p_message => 'l_expressions.count: %0'
-    , p0        => l_expressions.count
-    );
-
-    -- step through expressions
-    for i in 1..l_expressions.count loop
-      -- process expression
-      case l_expressions(i).expr_type
-        when flow_constants_pkg.gc_expr_type_static then
-          set_static 
-          ( pi_prcs_id      => pi_prcs_id
-          , pi_sbfl_id      => pi_sbfl_id
-          , pi_expression   => l_expressions(i)
-          );
-        when flow_constants_pkg.gc_expr_type_proc_var then
-          set_proc_var
-          ( pi_prcs_id    => pi_prcs_id
-          , pi_sbfl_id    => pi_sbfl_id
-          , pi_expression => l_expressions(i));
-        when flow_constants_pkg.gc_expr_type_sql  then
-          set_sql
-          ( pi_prcs_id => pi_prcs_id
-          , pi_expression => l_expressions(i)
-          , pi_sbfl_id => pi_sbfl_id);
-        when flow_constants_pkg.gc_expr_type_sql_delimited_list  then
-          set_sql_delimited
-          ( pi_prcs_id => pi_prcs_id
-          , pi_expression => l_expressions(i)
-          , pi_sbfl_id => pi_sbfl_id);     
-        when flow_constants_pkg.gc_expr_type_plsql_expression then
-          set_plsql_expression
-          ( pi_prcs_id => pi_prcs_id
-          , pi_expression => l_expressions(i)
-          , pi_sbfl_id => pi_sbfl_id); 
-        when flow_constants_pkg.gc_expr_type_plsql_function_body then
-          set_plsql_function
-          ( pi_prcs_id => pi_prcs_id
-          , pi_expression => l_expressions(i)
-          , pi_sbfl_id => pi_sbfl_id);  
-        else
-            null;
-      end case;
-    end loop;
+    if l_expressions.count > 0 then 
+      -- set context
+      flow_globals.set_context
+      ( pi_prcs_id => pi_prcs_id
+      , pi_sbfl_id => pi_sbfl_id
+      );
+      apex_debug.trace 
+      ( p_message => 'l_expressions.count: %0'
+      , p0        => l_expressions.count
+      );
+      -- step through expressions
+      for i in 1..l_expressions.count loop
+        -- process expression
+        case l_expressions(i).expr_type
+          when flow_constants_pkg.gc_expr_type_static then
+            set_static 
+            ( pi_prcs_id      => pi_prcs_id
+            , pi_sbfl_id      => pi_sbfl_id
+            , pi_expression   => l_expressions(i)
+            );
+          when flow_constants_pkg.gc_expr_type_proc_var then
+            set_proc_var
+            ( pi_prcs_id    => pi_prcs_id
+            , pi_sbfl_id    => pi_sbfl_id
+            , pi_expression => l_expressions(i));
+          when flow_constants_pkg.gc_expr_type_sql  then
+            set_sql
+            ( pi_prcs_id => pi_prcs_id
+            , pi_expression => l_expressions(i)
+            , pi_sbfl_id => pi_sbfl_id);
+          when flow_constants_pkg.gc_expr_type_sql_delimited_list  then
+            set_sql_delimited
+            ( pi_prcs_id => pi_prcs_id
+            , pi_expression => l_expressions(i)
+            , pi_sbfl_id => pi_sbfl_id);     
+          when flow_constants_pkg.gc_expr_type_plsql_expression then
+            set_plsql_expression
+            ( pi_prcs_id => pi_prcs_id
+            , pi_expression => l_expressions(i)
+            , pi_sbfl_id => pi_sbfl_id); 
+          when flow_constants_pkg.gc_expr_type_plsql_function_body then
+            set_plsql_function
+            ( pi_prcs_id => pi_prcs_id
+            , pi_expression => l_expressions(i)
+            , pi_sbfl_id => pi_sbfl_id);  
+          else
+              null;
+        end case;
+      end loop;
+    end if;
   end process_expressions;
 
   -- overloaded process_expressions that accepts a objt_bpmn_id rather than an objt_id

--- a/src/plsql/flow_plsql_runner_pkg.pkb
+++ b/src/plsql/flow_plsql_runner_pkg.pkb
@@ -19,14 +19,14 @@ as
     return flow_processes.prcs_id%type
   as
   begin
-    return g_current_prcs_id;
+    return flow_globals.process_id;
   end get_current_prcs_id;
 
   function get_current_sbfl_id
     return flow_subflows.sbfl_id%type
   as
   begin
-    return g_current_sbfl_id;
+    return flow_globals.subflow_id;
   end get_current_sbfl_id;
 
   procedure execute_plsql
@@ -67,7 +67,11 @@ as
     , 'pi_objt_id', pi_objt_id
     );
 
-    init_globals( pi_prcs_id => pi_prcs_id, pi_sbfl_id => pi_sbfl_id );
+    --init_globals( pi_prcs_id => pi_prcs_id, pi_sbfl_id => pi_sbfl_id );
+    flow_globals.set_context 
+    ( pi_prcs_id => pi_prcs_id
+    , pi_sbfl_id => pi_sbfl_id 
+    );
 
     for rec in ( select obat.obat_key
                       , obat.obat_vc_value

--- a/src/plsql/flow_plsql_runner_pkg.pks
+++ b/src/plsql/flow_plsql_runner_pkg.pks
@@ -5,6 +5,9 @@ as
   e_plsql_script_requested_stop exception;
   e_plsql_script_failed exception;
 
+  pragma deprecate (get_current_prcs_id, 'flow_plsql_runner_pkg.get_current_prcs_id is deprecated.  Use flow_globals.process_id instead');
+  pragma deprecate (get_current_sbfl_id, 'flow_plsql_runner_pkg.get_current_sbfl_id is deprecated.  Use flow_globals.subflow_id instead');
+
   function get_current_prcs_id
     return flow_processes.prcs_id%type
   ;


### PR DESCRIPTION
- adds / fixes flow_globals.subflow_id
- adds installation for flow_globals (sorry!)
- should work for variable expressions and plsql script runner
- marks old flow_plsql_runner_pkg.get_current_prcs_id and ...sbfl_id as deprecated.