### PR TITLE
flow_api.message, rename step_events, lgpr_objt_id

### DIFF
--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -352,6 +352,7 @@ create table flow_flow_event_log
 
 create table flow_instance_event_log
 ( lgpr_prcs_id           	NUMBER NOT NULL
+, lgpr_objt_id              VARCHAR2(50 CHAR) NULL
 , lgpr_dgrm_id      		NUMBER NOT NULL
 , lgpr_prcs_name         	VARCHAR2(150 CHAR) NOT NULL
 , lgpr_business_id			VARCHAR2(4000 char)
@@ -363,7 +364,7 @@ create table flow_instance_event_log
 );
 
 
-create table flow_subflow_event_log
+create table flow_step_event_log
 ( lgsf_prcs_id       		NUMBER NOT NULL
 , lgsf_objt_id       		VARCHAR2(50) NOT NULL
 , lgsf_sbfl_id      		NUMBER NOT NULL

--- a/src/deinstall_objects.sql
+++ b/src/deinstall_objects.sql
@@ -83,7 +83,7 @@ drop table flow_process_variables cascade constraints;
 drop table flow_object_expressions cascade constraints;
 drop table flow_flow_event_log cascade constraints;
 drop table flow_instance_event_log cascade constraints;
-drop table flow_subflow_event_log cascade constraints;
+drop table flow_step_event_log cascade constraints;
 drop table flow_variable_event_log cascade constraints;
 drop table flow_configuration cascade constraints;
 drop table flow_messages cascade constraints;

--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -318,5 +318,38 @@ end flow_complete_step;
       );
   end get_current_usertask_url;
 
+  function message
+  ( p_message_key    in varchar2
+  , p_lang            in varchar2 default 'en'
+  , p0                in varchar2 default null
+  , p1                in varchar2 default null
+  , p2                in varchar2 default null
+  , p3                in varchar2 default null
+  , p4                in varchar2 default null
+  , p5                in varchar2 default null
+  , p6                in varchar2 default null
+  , p7                in varchar2 default null
+  , p8                in varchar2 default null
+  , p9                in varchar2 default null
+  ) return varchar2
+  is
+  begin
+    return flow_errors.make_error_message
+           ( pi_message_key => p_message_key
+           , pi_lang        => p_lang
+           , p0   => p0
+           , p1   => p1
+           , p2   => p2
+           , p3   => p3
+           , p4   => p4
+           , p5   => p5
+           , p6   => p6
+           , p7   => p7
+           , p8   => p8
+           , p9   => p9
+           );
+
+  end message;
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -192,5 +192,22 @@ flow_delete ends all processing of a process instance.  It removes all subflows 
   , p_subflow_id in flow_subflows.sbfl_id%type
   ) return varchar2;
 
+  -- message
+  -- returns a Flows for APEX error message with p0...p9 substitutions in p_lang
+  function message
+  ( p_message_key     in varchar2 
+  , p_lang            in varchar2 default 'en'
+  , p0                in varchar2 default null
+  , p1                in varchar2 default null
+  , p2                in varchar2 default null
+  , p3                in varchar2 default null
+  , p4                in varchar2 default null
+  , p5                in varchar2 default null
+  , p6                in varchar2 default null
+  , p7                in varchar2 default null
+  , p8                in varchar2 default null
+  , p9                in varchar2 default null
+  ) return varchar2;
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -1425,9 +1425,10 @@ begin
   ;
   -- log the restart
   flow_logging.log_instance_event
-  ( p_process_id => p_process_id
-  , p_event      => flow_constants_pkg.gc_prcs_event_restart_step
-  , p_comment    => 'restart step '||l_sbfl_rec.sbfl_current||'. Comment: '||p_comment
+  ( p_process_id    => p_process_id
+  , p_event         => flow_constants_pkg.gc_prcs_event_restart_step
+  , p_objt_bpmn_id  => l_sbfl_rec.sbfl_current
+  , p_comment       => 'restart step '||l_sbfl_rec.sbfl_current||'. Comment: '||p_comment
   );
   -- see if instance can be reset to running
   select count(sbfl_id)
@@ -1443,6 +1444,7 @@ begin
     ;
     flow_logging.log_instance_event
     ( p_process_id => p_process_id
+    , p_objt_bpmn_id  => l_sbfl_rec.sbfl_current
     , p_event      => flow_constants_pkg.gc_prcs_status_running
     );
   end if;

--- a/src/plsql/flow_errors.pkb
+++ b/src/plsql/flow_errors.pkb
@@ -1,10 +1,11 @@
 create or replace package body flow_errors
-as
+as 
 
   g_logging_language        flow_configuration.cfig_value%type; 
 
   procedure autonomous_write_to_instance_log
   ( pi_prcs_id        in flow_processes.prcs_id%type
+  , pi_objt_bpmn_id   in flow_subflows.sbfl_current%type default null
   , pi_message        in flow_instance_event_log.lgpr_comment%type
   , pi_error_info     in flow_instance_event_log.lgpr_error_info%type
   )
@@ -14,6 +15,7 @@ as
     -- add to instance_event_log
     flow_logging.log_instance_event
     ( p_process_id        => pi_prcs_id
+    , p_objt_bpmn_id      => pi_objt_bpmn_id
     , p_event             => flow_constants_pkg.gc_prcs_event_error
     , p_comment           => pi_message
     , p_error_info        => pi_error_info
@@ -41,10 +43,9 @@ as
       ;   
   end set_error_status;
 
-  procedure handle_instance_error
-  ( pi_prcs_id        in flow_processes.prcs_id%type
-  , pi_sbfl_id        in flow_subflows.sbfl_id%type default null
-  , pi_message_key    in varchar2
+  function make_error_message
+  ( pi_message_key    in flow_messages.fmsg_message_key%type 
+  , pi_lang           in flow_messages.fmsg_lang%type
   , p0                in varchar2 default null
   , p1                in varchar2 default null
   , p2                in varchar2 default null
@@ -55,24 +56,18 @@ as
   , p7                in varchar2 default null
   , p8                in varchar2 default null
   , p9                in varchar2 default null
-  )
+  ) return flow_messages.fmsg_message_content%type
   is
     l_message_content  flow_messages.fmsg_message_content%type;
     l_message          flow_instance_event_log.lgpr_comment%type;
-    l_error_info       flow_instance_event_log.lgpr_error_info%type;
   begin 
-    apex_debug.enter
-    ( 'handle_instance_error'
-    , 'pi_sbfl_id', pi_sbfl_id
-    , 'pi_message_key', pi_message_key
-    );
     -- get the message template in the correct language, or fall through to default language
     begin
       select fmsg.fmsg_message_content
         into l_message_content
         from flow_messages fmsg
        where fmsg.fmsg_message_key = pi_message_key
-         and fmsg.fmsg_lang = g_logging_language
+         and fmsg.fmsg_lang = pi_lang
       ;
     exception
       when no_data_found then
@@ -107,11 +102,73 @@ as
                   , p8 => p8
                   , p9 => p9
                   );
+    return l_message;
+  end make_error_message;
+
+  procedure handle_instance_error
+  ( pi_prcs_id        in flow_processes.prcs_id%type
+  , pi_sbfl_id        in flow_subflows.sbfl_id%type default null
+  , pi_message_key    in varchar2
+  , p0                in varchar2 default null
+  , p1                in varchar2 default null
+  , p2                in varchar2 default null
+  , p3                in varchar2 default null
+  , p4                in varchar2 default null
+  , p5                in varchar2 default null
+  , p6                in varchar2 default null
+  , p7                in varchar2 default null
+  , p8                in varchar2 default null
+  , p9                in varchar2 default null
+  )
+  is
+    l_message_content  flow_messages.fmsg_message_content%type;
+    l_message          flow_instance_event_log.lgpr_comment%type;
+    l_error_info       flow_instance_event_log.lgpr_error_info%type;
+    l_current          flow_subflows.sbfl_current%type;
+  begin 
+    apex_debug.enter
+    ( 'handle_instance_error'
+    , 'pi_sbfl_id', pi_sbfl_id
+    , 'pi_message_key', pi_message_key
+    , 'is_recursive' , case when flow_globals.get_is_recursive_step then 'true' else 'false' end
+    );
+    -- get the message template in the correct language, or fall through to default language
+    -- for log & apex_error
+    l_message :=  make_error_message
+                  ( pi_message_key   => pi_message_key
+                  , pi_lang          => g_logging_language
+                  , p0               => p0
+                  , p1               => p1
+                  , p2               => p2
+                  , p3               => p3
+                  , p4               => p4
+                  , p5               => p5
+                  , p6               => p6
+                  , p7               => p7
+                  , p8               => p8
+                  , p9               => p9
+                  );
     -- get the error stack and step type
     l_error_info   := dbms_utility.format_error_stack;
+    -- get the current step, if known & available
+    begin
+      if pi_sbfl_id is not null then
+        select sbfl.sbfl_current
+          into l_current
+          from flow_subflows sbfl
+        where sbfl.sbfl_id = pi_sbfl_id
+        ;
+      else
+        l_current := null;
+      end if;
+    exception
+      when others then
+        l_current := null;
+    end; 
     -- add to instance_event_log
     autonomous_write_to_instance_log
     ( pi_prcs_id        => pi_prcs_id
+    , pi_objt_bpmn_id   => l_current
     , pi_message        => l_message
     , pi_error_info     => l_error_info
     );
@@ -127,6 +184,49 @@ as
       );
     end if;
   end handle_instance_error;
+
+  procedure handle_general_error
+  ( pi_message_key    in varchar2
+  , p0                in varchar2 default null
+  , p1                in varchar2 default null
+  , p2                in varchar2 default null
+  , p3                in varchar2 default null
+  , p4                in varchar2 default null
+  , p5                in varchar2 default null
+  , p6                in varchar2 default null
+  , p7                in varchar2 default null
+  , p8                in varchar2 default null
+  , p9                in varchar2 default null
+  )
+  is
+    l_message_content  flow_messages.fmsg_message_content%type;
+    l_message          flow_instance_event_log.lgpr_comment%type;
+  begin 
+    apex_debug.enter
+    ( 'handle_instance_error'
+    , 'pi_message_key', pi_message_key
+    );
+    -- get the message template in the correct language, or fall through to default language
+    -- for log & apex_error
+    l_message :=  make_error_message
+                  ( pi_message_key   => pi_message_key
+                  , pi_lang          => g_logging_language
+                  , p0               => p0
+                  , p1               => p1
+                  , p2               => p2
+                  , p3               => p3
+                  , p4               => p4
+                  , p5               => p5
+                  , p6               => p6
+                  , p7               => p7
+                  , p8               => p8
+                  , p9               => p9
+                  );
+    apex_error.add_error
+      ( p_message => l_message
+      , p_display_location => apex_error.c_on_error_page
+      );
+  end handle_general_error;
 
   -- initialize logging parameters
 

--- a/src/plsql/flow_errors.pks
+++ b/src/plsql/flow_errors.pks
@@ -21,6 +21,21 @@ as
   ( pi_prcs_id        in flow_processes.prcs_id%type
   , pi_sbfl_id        in flow_subflows.sbfl_id%type
   );
+  
+  function make_error_message
+  ( pi_message_key    in flow_messages.fmsg_message_key%type 
+  , pi_lang           in flow_messages.fmsg_lang%type
+  , p0                in varchar2 default null
+  , p1                in varchar2 default null
+  , p2                in varchar2 default null
+  , p3                in varchar2 default null
+  , p4                in varchar2 default null
+  , p5                in varchar2 default null
+  , p6                in varchar2 default null
+  , p7                in varchar2 default null
+  , p8                in varchar2 default null
+  , p9                in varchar2 default null
+  ) return flow_messages.fmsg_message_content%type;
 
 end flow_errors;
 /

--- a/src/plsql/flow_logging.pkb
+++ b/src/plsql/flow_logging.pkb
@@ -6,6 +6,7 @@ as
 
   procedure log_instance_event
   ( p_process_id        in flow_subflow_log.sflg_prcs_id%type
+  , p_objt_bpmn_id      in flow_objects.objt_bpmn_id%type default null
   , p_event             in flow_instance_event_log.lgpr_prcs_event%type 
   , p_comment           in flow_instance_event_log.lgpr_comment%type default null
   , p_error_info        in flow_instance_event_log.lgpr_error_info%type default null
@@ -19,6 +20,7 @@ as
     then
       insert into flow_instance_event_log
       ( lgpr_prcs_id 
+      , lgpr_objt_id
       , lgpr_dgrm_id 
       , lgpr_prcs_name 
       , lgpr_business_id
@@ -29,6 +31,7 @@ as
       , lgpr_error_info
       )
       select prcs.prcs_id
+          , p_objt_bpmn_id
           , prcs.prcs_dgrm_id
           , prcs.prcs_name
           , flow_process_vars.get_business_ref (p_process_id)  --- 
@@ -87,7 +90,7 @@ as
                           , flow_constants_pkg.gc_config_logging_level_full
                           ) 
     then
-      insert into flow_subflow_event_log
+      insert into flow_step_event_log
       ( lgsf_prcs_id 
       , lgsf_objt_id 
       , lgsf_sbfl_id 

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -6,6 +6,7 @@ as
 
   procedure log_instance_event
   ( p_process_id        in flow_subflow_log.sflg_prcs_id%type
+  , p_objt_bpmn_id      in flow_objects.objt_bpmn_id%type default null
   , p_event             in flow_instance_event_log.lgpr_prcs_event%type 
   , p_comment           in flow_instance_event_log.lgpr_comment%type default null
   , p_error_info        in flow_instance_event_log.lgpr_error_info%type default null

--- a/src/plsql/flow_tasks.pkb
+++ b/src/plsql/flow_tasks.pkb
@@ -44,6 +44,7 @@ as
       -- log error as instance event
       flow_logging.log_instance_event
       ( p_process_id  => p_process_id 
+      , p_objt_bpmn_id => p_script_object
       , p_event       => flow_constants_pkg.gc_prcs_event_error
       , p_comment     => case p_error_type
                          when 'failed'      then 'ScriptTask failed on object '

--- a/src/views/engine-app/flow_p0013_subflow_log_vw.sql
+++ b/src/views/engine-app/flow_p0013_subflow_log_vw.sql
@@ -1,4 +1,4 @@
-create or replace view flow_p0013_subflow_log_vw
+create or replace view flow_p0013_step_log_vw
 as
   select lgsf.lgsf_prcs_id
        , lgsf.lgsf_objt_id
@@ -12,5 +12,5 @@ as
        , lgsf.lgsf_reservation
        , lgsf.lgsf_user
        , lgsf.lgsf_comment
-    from flow_subflow_event_log lgsf
+    from flow_step_event_log lgsf
 with read only;

--- a/src/views/engine-app/flow_p0014_instance_log_vw.sql
+++ b/src/views/engine-app/flow_p0014_instance_log_vw.sql
@@ -1,6 +1,7 @@
 create or replace view flow_p0014_instance_log_vw
 as
   select lgpr.lgpr_prcs_id
+       , lgpr.lgpr_objt_id
        , lgpr.lgpr_prcs_name
        , lgpr.lgpr_business_id
        , lgpr.lgpr_prcs_event

--- a/src/views/engine-app/flow_p0014_subflow_log_vw.sql
+++ b/src/views/engine-app/flow_p0014_subflow_log_vw.sql
@@ -1,4 +1,4 @@
-create or replace view flow_p0014_subflow_log_vw
+create or replace view flow_p0014_step_log_vw
 as
   select distinct lgsf.lgsf_prcs_id
                 , coalesce(objt.objt_name, lgsf.lgsf_objt_id) as completed_object
@@ -12,7 +12,7 @@ as
                 , lgsf.lgsf_reservation
                 , lgsf.lgsf_user
                 , lgsf.lgsf_comment
-             from flow_subflow_event_log lgsf
+             from flow_step_event_log lgsf
              join flow_objects objt
                on lgsf.lgsf_objt_id = objt.objt_bpmn_id
 with read only;


### PR DESCRIPTION
- adds flow_api.message so that plugins can use our message mechanism
- changes flow_subflow_event_log into flow_step_event_log
- adds step object (bpmn_id) to flow_instance_event_log
- @LouisMoreaux will fix engine_app once this is in dev.