### PR TITLE
Fixes #367 Clear Error Flag after GW Split

### DIFF
--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -364,6 +364,8 @@ as
         );
       end if;
     end loop;
+    -- reset step_had_error flag
+    flow_globals.set_step_error ( p_has_error => false);
   end gateway_split;
 
   procedure process_para_incl_Gateway


### PR DESCRIPTION
Fixes Issue #367 - Error Flag was not reset after completing the move forward on all Parallel / Inclusive Gateway Splits, resulting in the parent subflow also being put into error status if the last subflow to be processed had an error.

This is a bug in 21.1 and should be available for a hot fix if required.  (1 line change in flow_gateways.pkb)