### PR TITLE
engine complete - for testing

### DIFF
--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -290,7 +290,7 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'timer-broken',
 'en',
-'Timer %0 broken in process %1 , subflow : %2.  See error_info.'
+'Timer %0 Run %4 broken in process %1 , subflow : %2.  See error_info.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
@@ -304,7 +304,7 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'timer-incomplete-definition',
 'en',
-'Incomplete timer definitions for object %0. Type: %1; Value: %2'
+'Incomplete timer definitions for object %0. Type: %1; Value1: %2 Value2: %3  Value3: %4'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )

--- a/src/data/install_engine_messages_fr.sql
+++ b/src/data/install_engine_messages_fr.sql
@@ -288,7 +288,7 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'timer-broken',
 'fr',
-'Minuteur %0 en erreur dans le processus %1 , sous-flux : %2.  Voir error_info.'
+'Minuteur %0 cycle %4 en erreur dans le processus %1 , sous-flux : %2.  Voir error_info.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
@@ -302,7 +302,7 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'timer-incomplete-definition',
 'fr',
-'Définition incomplète du minuteur de l''objet %0. Type: %1; Valeur: %2'
+'Définition incomplète du minuteur de l''objet %0. Type: %1; Valeur1: %2 Valeur2: %3 Valeur3: %4'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )

--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -229,7 +229,29 @@ as
     , p_step_key   => p_step_key
     , p_recursive_call => false
     );
-end flow_complete_step;
+  end flow_complete_step;
+
+  procedure flow_reschedule_timer
+  (
+      p_process_id    in flow_processes.prcs_id%type
+    , p_subflow_id    in flow_subflows.sbfl_id%type
+    , p_step_key      in flow_subflows.sbfl_step_key%type default null
+    , p_is_immediate  in boolean default false
+    , p_new_timestamp in flow_timers.timr_start_on%type default null
+    , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+  )
+  is
+  begin
+    flow_timers_pkg.reschedule_timer
+    ( 
+      p_process_id    => p_process_id
+    , p_subflow_id    => p_subflow_id
+    , p_step_key      => p_step_key 
+    , p_is_immediate  => p_is_immediate
+    , p_new_timestamp => p_new_timestamp
+    , p_comment       => p_comment
+    );
+  end flow_reschedule_timer;
 
   procedure flow_reset
   ( p_process_id in flow_processes.prcs_id%type

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -143,6 +143,30 @@ is used to move a process forward, regardless of the object type.
   , p_step_key      in flow_subflows.sbfl_step_key%type default null
   ); 
 
+/*** 
+Procedure flow_reschedulule_timer
+flow_reschedule_timer can be called to change the next scheduled time of a timer on a running timer.
+It can change the currently scheduled time to a future time, or can instruct the timer to fire immediately.
+If the Timer event is a single event timer (timer types Date or Duration), it will change the time at which the event is 
+scheduled to occur to the new time.
+If the timer is a Cycle Timer, this changes the time that the next firoing is scheduled to occur.  If later cycles exist, the following cycle will 
+be scheduled at the new firing time + the repeat interval.
+To fire the timer immediately, set p_is_immediate = true.
+To change the firing time to another future time, supply a new timestamp with time zone contaiing the new time.
+A comment can be provided, which is passed to the log file for explanation of any rescheduling.
+*/
+procedure flow_reschedule_timer
+(
+    p_process_id    in flow_processes.prcs_id%type
+  , p_subflow_id    in flow_subflows.sbfl_id%type
+  , p_step_key      in flow_subflows.sbfl_step_key%type default null
+  , p_is_immediate  in boolean default false
+  , p_new_timestamp in flow_timers.timr_start_on%type default null
+  , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+
+);
+
+
 /***
 Procedure flow_reset
 flow_reset aborts all processing on a process instance, and returns it to the state when it was

--- a/src/plsql/flow_boundary_events.pkb
+++ b/src/plsql/flow_boundary_events.pkb
@@ -62,7 +62,7 @@ is
           , p_parent_subflow => p_subflow_id
           , p_starting_object => boundary_timers.objt_bpmn_id
           , p_current_object => boundary_timers.objt_bpmn_id
-          , p_route => 'from boundary event - run 0'
+          , p_route => 'from boundary event - run 1'
           , p_last_completed => boundary_timers.parent_current_object 
           , p_status => flow_constants_pkg.gc_sbfl_status_waiting_timer
           , p_parent_sbfl_proc_level => boundary_timers.sbfl_process_level

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -79,20 +79,22 @@ as
 
   gc_timer_tag_oracle_date            constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'oracleDate';
   gc_timer_tag_oracle_date_mask       constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'oracleFormatMask';
-  gc_timer_tag_oracle_duration        constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'oracleDuration';
-  gc_timer_tag_start_interval         constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'startInterval';
-  gc_timer_tag_repeat_interval        constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'repeatInterval';
-  gc_timer_tag_max_repeats            constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'maxRepeats';
+  gc_timer_tag_oracle_duration_ds     constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'oracleDurationDS';
+  gc_timer_tag_oracle_duration_ym     constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'oracleDurationYM';
+  gc_timer_tag_start_interval_ds      constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'startIntervalDS';
+  gc_timer_tag_repeat_interval_ds     constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'repeatIntervalDS';
+  gc_timer_tag_max_runs               constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'maxRuns';
 
   -- Special Keys from FLOW_OBJECT_ATTRIBUTES
   gc_timer_type_key                   constant flow_types_pkg.t_bpmn_id := 'timerType';
   gc_timer_def_key                    constant flow_types_pkg.t_bpmn_id := 'timerDefinition';
   gc_timer_oracle_date_key            constant flow_types_pkg.t_bpmn_id := 'oracleDate';
   gc_timer_oracle_date_mask_key       constant flow_types_pkg.t_bpmn_id := 'oracleFormatMask';
-  gc_timer_oracle_duration_key        constant flow_types_pkg.t_bpmn_id := 'oracleDuration';
-  gc_timer_start_interval_key         constant flow_types_pkg.t_bpmn_id := 'startInterval';
-  gc_timer_repeat_interval_key        constant flow_types_pkg.t_bpmn_id := 'repeatInterval';
-  gc_timer_max_repeats_key            constant flow_types_pkg.t_bpmn_id := 'maxRepeats';
+  gc_timer_oracle_durationDS_key      constant flow_types_pkg.t_bpmn_id := 'oracleDurationDS';
+  gc_timer_oracle_durationYM_key      constant flow_types_pkg.t_bpmn_id := 'oracleDurationYM';
+  gc_timer_start_intervalDS_key       constant flow_types_pkg.t_bpmn_id := 'startIntervalDS';
+  gc_timer_repeat_intervalDS_key      constant flow_types_pkg.t_bpmn_id := 'repeatIntervalDS';
+  gc_timer_max_runs_key               constant flow_types_pkg.t_bpmn_id := 'maxRuns';
   
   gc_terminate_result                 constant flow_types_pkg.t_bpmn_id := 'processStatus';
 
@@ -139,6 +141,7 @@ as
   gc_prcs_event_error                constant  varchar2(20 char) := gc_prcs_status_error;
   gc_prcs_event_restart_step         constant  varchar2(20 char) := 'restart step';
   gc_prcs_event_deleted              constant  varchar2(20 char) := 'deleted';
+  gc_prcs_event_rescheduled          constant  varchar2(20 char) := 'rescheduled';
 
   -- Process Variable Datatypes
 

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -1,6 +1,6 @@
 create or replace package flow_logging
 accessible by ( flow_engine, flow_instances, flow_process_vars, flow_expressions 
-              , flow_boundary_events, flow_gateways, flow_tasks, flow_errors
+              , flow_boundary_events, flow_gateways, flow_tasks, flow_errors, flow_timers_pkg
               )
 as
 

--- a/src/plsql/flow_timers_pkg.pkb
+++ b/src/plsql/flow_timers_pkg.pkb
@@ -14,9 +14,10 @@ as
   , oracle_date           flow_object_attributes.obat_vc_value%type
   , oracle_format_mask    flow_object_attributes.obat_vc_value%type
   , oracle_duration_ds    flow_object_attributes.obat_vc_value%type
+  , oracle_duration_ym    flow_object_attributes.obat_vc_value%type
   , start_interval_ds     flow_object_attributes.obat_vc_value%type
   , repeat_interval_ds    flow_object_attributes.obat_vc_value%type
-  , max_repeats           flow_object_attributes.obat_vc_value%type
+  , max_runs              flow_object_attributes.obat_vc_value%type
   );
 
   function timer_exists
@@ -159,10 +160,11 @@ as
                                         , flow_constants_pkg.gc_timer_def_key 
                                         , flow_constants_pkg.gc_timer_oracle_date_key
                                         , flow_constants_pkg.gc_timer_oracle_date_mask_key
-                                        , flow_constants_pkg.gc_timer_oracle_duration_key
-                                        , flow_constants_pkg.gc_timer_start_interval_key
-                                        , flow_constants_pkg.gc_timer_repeat_interval_key
-                                        , flow_constants_pkg.gc_timer_max_repeats_key
+                                        , flow_constants_pkg.gc_timer_oracle_durationDS_key
+                                        , flow_constants_pkg.gc_timer_oracle_durationYM_key
+                                        , flow_constants_pkg.gc_timer_start_intervalDS_key
+                                        , flow_constants_pkg.gc_timer_repeat_intervalDS_key
+                                        , flow_constants_pkg.gc_timer_max_runs_key
                                         )
                )
     loop
@@ -175,14 +177,16 @@ as
           l_timer_def.oracle_date := rec.obat_vc_value;
         when flow_constants_pkg.gc_timer_oracle_date_mask_key then
           l_timer_def.oracle_format_mask := rec.obat_vc_value;
-        when flow_constants_pkg.gc_timer_oracle_duration_key then
+        when flow_constants_pkg.gc_timer_oracle_durationDS_key then
           l_timer_def.oracle_duration_ds := rec.obat_vc_value;
-        when flow_constants_pkg.gc_timer_start_interval_key  then
+        when flow_constants_pkg.gc_timer_oracle_durationYM_key then
+          l_timer_def.oracle_duration_ym := rec.obat_vc_value;
+        when flow_constants_pkg.gc_timer_start_intervalDS_key  then
           l_timer_def.start_interval_ds := rec.obat_vc_value;
-        when flow_constants_pkg.gc_timer_repeat_interval_key then
+        when flow_constants_pkg.gc_timer_repeat_intervalDS_key then
           l_timer_def.repeat_interval_ds  := rec.obat_vc_value;
-        when flow_constants_pkg.gc_timer_max_repeats_key then
-          l_timer_def.max_repeats  := rec.obat_vc_value;
+        when flow_constants_pkg.gc_timer_max_runs_key then
+          l_timer_def.max_runs  := rec.obat_vc_value;
         else
           null;
       end case;
@@ -203,12 +207,13 @@ as
        or 
        ( l_timer_def.timer_type = flow_constants_pkg.gc_timer_type_oracle_duration
          and  l_timer_def.oracle_duration_ds is null 
+         and  l_timer_def.oracle_duration_ym is null
        )
        or 
        ( l_timer_def.timer_type = flow_constants_pkg.gc_timer_type_oracle_cycle
          and  (l_timer_def.start_interval_ds is null 
               or l_timer_def.repeat_interval_ds is null 
-               )  -- note - maxRepeats is allowed to be null (means no limit)
+               )  -- note - maxRuns is allowed to be null (means no limit)
        )
     then
       flow_errors.handle_instance_error
@@ -216,20 +221,14 @@ as
       , pi_sbfl_id        => pi_sbfl_id
       , pi_message_key    => 'timer-incomplete-definition'
       , p0 => l_objt_with_timer_bpmn_id         
-	    , p1 => coalesce(l_timer_def.timer_type, '!NULL!')
-      , p2 => coalesce(l_timer_def.timer_definition, '!NULL!')
+	    , p1 => coalesce ( l_timer_def.timer_type,  '!NULL!')
+      , p2 => coalesce ( l_timer_def.timer_definition, l_timer_def.oracle_date
+                       , l_timer_def.oracle_duration_ds, l_timer_def.start_interval_ds , '!NULL!')
+      , p3 => coalesce ( l_timer_def.oracle_format_mask
+                       , l_timer_def.oracle_duration_ym, l_timer_def.repeat_interval_ds,'!NULL!')
+      , p4 => coalesce ( l_timer_def.max_runs,'!NULL!')                       
       );
-      -- $F4AMESSAGE 'timer-incomplete-definition' || 'Incomplete timer definitions for object %0. Type: %1; Value: %2'
-/*    elsif l_timer_def.timer_type = flow_constants_pkg.gc_timer_type_cycle then
-      -- cycle timers disabled in v21.1 until redone in future release
-      flow_errors.handle_instance_error
-      ( pi_prcs_id        => pi_prcs_id
-      , pi_sbfl_id        => pi_sbfl_id
-      , pi_message_key    => 'timer-cycle-unsupported'
-      , p0 => l_objt_with_timer_bpmn_id         
-      );
-      -- $F4AMESSAGE 'timer-cycle-unsupported' || 'Cycle Timer defined for object %0 not currently supported.'
-*/
+      -- $F4AMESSAGE 'timer-incomplete-definition' || 'Incomplete timer definitions for object %0. Type: %1; Value1: %2 Value2: %3  Value3: %4'
     end if;
     return l_timer_def;
   end get_timer_definition;
@@ -255,20 +254,19 @@ as
           select max(rowid) keep (dense_rank first order by coalesce( timr_last_run, timr_created_on )) trowid
             from flow_timers
            where timr_status = c_created
-             and coalesce( timr_last_run, timr_created_on )  < l_run_time 
+             --and coalesce( timr_last_run, timr_created_on )  < l_run_time 
              and timr_start_on <= l_run_time
           )
       for update wait 5
       ;
       
-/*
-
       update flow_timers
       set timr_last_run = systimestamp
           , timr_status = c_ended
       where timr_id = l_timers.timr_id
+        and timr_run = l_timers.timr_run
       ;
-*/              
+            
       begin
       -- ideally the flow_engine should lock the subflow and this procedure should handle the resource 
       -- timeout, deadlock and not found exceptions. This would happen if the subflow is locked waiting 
@@ -300,6 +298,7 @@ as
         update flow_timers
           set timr_status = c_broken
         where timr_id = l_timers.timr_id
+          and timr_run = l_timers.timr_run
         ;
         flow_errors.handle_instance_error
         ( pi_prcs_id    => l_timers.timr_prcs_id
@@ -308,8 +307,9 @@ as
         , p0 => l_timers.timr_id
         , p1 => l_timers.timr_prcs_id
         , p2 => l_timers.timr_sbfl_id
+        , p3 => l_timers.timr_run
         );
-        -- $F4AMESSAGE 'timer-broken' || 'Timer %0 broken in process %1 , subflow : %2.  See error_info.'
+        -- $F4AMESSAGE 'timer-broken' || 'Timer %0 Run %4 broken in process %1 , subflow : %2.  See error_info.'
       end;
       commit;
     end loop;
@@ -418,7 +418,7 @@ as
     , p2        => coalesce( l_timer_def.timer_definition , l_timer_def.oracle_date
                            , l_timer_def.oracle_duration_DS,  l_timer_def.start_Interval_DS , '<null>')
     , p3        => coalesce( l_timer_def.oracle_format_mask, l_timer_def.repeat_interval_ds, '<null>')
-    , p4        => coalesce( l_timer_def.max_Repeats, '<null>')
+    , p4        => coalesce( l_timer_def.max_runs, '<null>')
     );
 
     case l_timer_def.timer_type
@@ -510,7 +510,7 @@ as
 
         if upper(substr(l_timer_def.oracle_date,1,5)) = flow_constants_pkg.gc_substitution_prefix || flow_constants_pkg.gc_substitution_flow_identifier then
           case flow_process_vars.get_var_type ( pi_prcs_id  => pi_prcs_id
-                                              , pi_var_name => substr(l_timer_def.oracle_daten,6,length(l_timer_def.oracle_date)-6)
+                                              , pi_var_name => substr(l_timer_def.oracle_date,6,length(l_timer_def.oracle_date)-6)
                                               )
           when flow_constants_pkg.gc_prov_var_type_date then
               -- substitution parameter is a date process var = already an Oracle date
@@ -537,26 +537,39 @@ as
           l_parsed_ts := to_timestamp ( l_timer_def.oracle_date, l_timer_def.oracle_format_mask);
         end if;
       when flow_constants_pkg.gc_timer_type_oracle_duration then 
-        if upper(substr(l_timer_def.oracle_date,1,5)) = flow_constants_pkg.gc_substitution_prefix || flow_constants_pkg.gc_substitution_flow_identifier then
+        if upper(substr(l_timer_def.oracle_duration_ds,1,5)) = flow_constants_pkg.gc_substitution_prefix || flow_constants_pkg.gc_substitution_flow_identifier then
         
-          l_parsed_ts := systimestamp + to_dsinterval ( flow_process_vars.get_var_vc2
+          l_parsed_duration_ds :=  to_dsinterval ( nvl ( flow_process_vars.get_var_vc2
                                                               ( pi_prcs_id => pi_prcs_id
-                                                              , pi_var_name => substr ( l_timer_def.oracle_duration , 6
-                                                                                      , length(l_timer_def.oracle_duration ) - 6
+                                                              , pi_var_name => substr ( l_timer_def.oracle_duration_ds , 6
+                                                                                      , length(l_timer_def.oracle_duration_ds ) - 6
                                                                                       )
-                                                              )
-                                                      );
+                                                              ) , '000 00:00:00' )
+                                                  );
         else  
-        
-          l_parsed_ts := systimestamp + to_dsinterval(l_timer_def.oracle_duration_ds);
+          l_parsed_duration_ds := to_dsinterval ( nvl ( l_timer_def.oracle_duration_ds , '000 00:00:00') );
         end if;
+
+        if upper(substr(l_timer_def.oracle_duration_ym,1,5)) = flow_constants_pkg.gc_substitution_prefix || flow_constants_pkg.gc_substitution_flow_identifier then
+        
+          l_parsed_duration_ym :=  to_yminterval ( nvl( flow_process_vars.get_var_vc2
+                                                              ( pi_prcs_id => pi_prcs_id
+                                                              , pi_var_name => substr ( l_timer_def.oracle_duration_ym , 6
+                                                                                      , length(l_timer_def.oracle_duration_ym ) - 6
+                                                                                      )
+                                                              ), '0-0')
+                                                  );
+        else  
+          l_parsed_duration_ym := to_yminterval ( nvl( l_timer_def.oracle_duration_ym, '0-0') );
+        end if;
+        l_parsed_ts := systimestamp + l_parsed_duration_ym + l_parsed_duration_ds;
 
       when flow_constants_pkg.gc_timer_type_oracle_cycle then
 
         l_parsed_ts           := systimestamp + to_dsinterval ( l_timer_def.start_interval_ds );
         l_parsed_duration_ym  := to_yminterval ('0-0');  -- UI currently does not allow YM input so set to 0
         l_parsed_duration_ds  := to_dsinterval ( l_timer_def.repeat_interval_ds );
-        l_repeat_times        := to_number ( l_timer_def.max_repeats );
+        l_repeat_times        := to_number ( l_timer_def.max_runs );
       else
         flow_errors.handle_instance_error
         ( pi_prcs_id        => pi_prcs_id
@@ -588,7 +601,7 @@ as
         pi_prcs_id
       , pi_sbfl_id
       , pi_step_key
-      , 0
+      , 1
       , l_timer_def.timer_type
       , systimestamp
       , c_created
@@ -617,7 +630,7 @@ as
     pi_prcs_id    in flow_processes.prcs_id%type
   , pi_sbfl_id    in flow_subflows.sbfl_id%type 
   , pi_step_key   in flow_subflows.sbfl_step_key%type default null
-  , pi_run        in flow_timers.timr_run%type default 0 -- 0 original, 1-> repeats
+  , pi_run        in flow_timers.timr_run%type default 1 -- 1 original, 2-> repeats
   , pi_timr_id    in flow_timers.timr_id%type default null -- only set on repeats
   )
   as
@@ -676,7 +689,7 @@ as
     pi_prcs_id    in flow_processes.prcs_id%type
   , pi_sbfl_id    in flow_subflows.sbfl_id%type 
   , pi_step_key   in flow_subflows.sbfl_step_key%type default null
-  , pi_run        in flow_timers.timr_run%type default 0 -- 1 original, 2-> repeats
+  , pi_run        in flow_timers.timr_run%type default 1 -- 1 original, 2-> repeats
   , pi_timr_id    in flow_timers.timr_id%type default null -- only set on repeats
   )
   as
@@ -694,14 +707,14 @@ as
     , 'timr_id (repeats)', pi_timr_id
     , 'timer run', pi_run
     );
-    if pi_run = 0 and pi_timr_id is null then
+    if pi_run = 1 and pi_timr_id is null then
       -- starting the first run of a new timer
       start_new_timer
       ( pi_prcs_id   => pi_prcs_id   
       , pi_sbfl_id   => pi_sbfl_id  
       , pi_step_key  => pi_step_key 
       );
-    elsif pi_run > 0 and pi_timr_id is not null then
+    elsif pi_run > 1 and pi_timr_id is not null then
         -- starting a repeat cycle of a existing timer (on a new sbfl)
       start_repeat_timer
       ( pi_prcs_id   => pi_prcs_id   
@@ -722,6 +735,106 @@ as
         -- $F4AMESSAGE 'timer-internal-error' || 'Timer internal error  for object %0. Type: %1; Value: %2'
     end if;
   end start_timer;
+
+/******************************************************************************
+  RESCHEDULE_TIMER
+*******************************************************************************/
+
+procedure reschedule_timer
+(
+    p_process_id    in flow_processes.prcs_id%type
+  , p_subflow_id    in flow_subflows.sbfl_id%type
+  , p_step_key      in flow_subflows.sbfl_step_key%type default null
+  , p_is_immediate  in boolean default false
+  , p_new_timestamp in flow_timers.timr_start_on%type default null
+  , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+)
+is
+  l_timer_rec       flow_timers%rowtype;
+  e_bad_new_timer   exception;
+  l_current_object  flow_subflows.sbfl_current%type;
+begin
+  apex_debug.enter 
+  ( 'reschedule_timer'
+  , 'Process ID',  p_process_id
+  , 'Subflow ID', p_subflow_id
+  , 'Step Key', p_step_key
+  , 'Immediate', case when p_is_immediate then 'true' else 'false' end
+  , 'New Timestamp', p_new_timestamp
+  );
+  -- lock the timer
+  select *
+    into l_timer_rec
+    from flow_timers timr 
+   where timr.timr_prcs_id = p_process_id
+     and timr.timr_sbfl_id = p_subflow_id
+     for update wait 5
+  ;
+  if flow_engine_util.step_key_valid( pi_prcs_id  => p_process_id
+                                    , pi_sbfl_id  => p_subflow_id
+                                    , pi_step_key_supplied  => p_step_key
+                                    , pi_step_key_required  => l_timer_rec.timr_step_key) then 
+    if p_is_immediate then
+      l_timer_rec.timr_start_on := systimestamp;
+    elsif p_new_timestamp >= systimestamp then
+      l_timer_rec.timr_start_on := p_new_timestamp;
+    elsif not p_is_immediate  and p_new_timestamp is null then
+      raise e_bad_new_timer;
+    end if;
+
+    update flow_timers
+       set timr_start_on = l_timer_rec.timr_start_on
+     where timr_id = l_timer_rec.timr_id
+       and timr_run = l_timer_rec.timr_run
+    ;
+
+    select sbfl.sbfl_current
+      into l_current_object
+      from flow_subflows sbfl
+     where sbfl.sbfl_id = p_subflow_id
+       and sbfl.sbfl_prcs_id = p_process_id
+    ;
+
+    flow_logging.log_instance_event
+    ( p_process_id  => p_process_id
+    , p_objt_bpmn_id  => l_current_object
+    , p_event  => flow_constants_pkg.gc_prcs_event_rescheduled
+    , p_comment  => p_comment
+    );
+
+  end if;
+exception
+  when no_data_found then
+      flow_errors.handle_instance_error
+      ( pi_prcs_id     => p_process_id
+      , pi_sbfl_id     => p_subflow_id
+      , pi_message_key => 'engine-util-sbfl-not-found'
+      , p0 => p_subflow_id
+      );
+      -- $F4AMESSAGE 'engine-util-sbfl-not-found' || 'Subflow ID supplied ( %0 ) not found. Check for process events that changed process flow (timeouts, errors, escalations).'  
+  when lock_timeout then
+      flow_errors.handle_instance_error
+      ( pi_prcs_id     => p_process_id
+      , pi_sbfl_id     => p_subflow_id
+      , pi_message_key => 'timeout_locking_subflow'
+      , p0 => p_subflow_id
+      );
+      -- $F4AMESSAGE 'timeout_locking_subflow' || 'Unable to lock subflow %0 as currently locked by another user.  Retry your transaction later.'  
+  when e_bad_new_timer then
+        flow_errors.handle_instance_error
+        ( pi_prcs_id        => p_process_id
+        , pi_sbfl_id        => p_subflow_id
+        , pi_message_key    => 'timer-incomplete-definition'
+        , p0 => p_subflow_id       
+	      , p1 => case when p_is_immediate then 'true' else 'false' end
+        , p2 => p_new_timestamp
+        );
+        -- $F4AMESSAGE 'timer-incomplete-definition' || 'Incomplete timer definitions for object %0. Type: %1; Value: %2'
+
+end reschedule_timer;
+
+
+
 
 /******************************************************************************
   EXPIRE_TIMER

--- a/src/plsql/flow_timers_pkg.pks
+++ b/src/plsql/flow_timers_pkg.pks
@@ -42,9 +42,25 @@ create or replace package flow_timers_pkg as
     pi_prcs_id    in flow_processes.prcs_id%type
   , pi_sbfl_id    in flow_subflows.sbfl_id%type
   , pi_step_key   in flow_subflows.sbfl_step_key%type default null
-  , pi_run        in flow_timers.timr_run%type default 0 -- 0 original, 1-> repeats
+  , pi_run        in flow_timers.timr_run%type default 1 -- 1 original, 2-> repeats
   , pi_timr_id    in flow_timers.timr_id%type default null -- only set on repeats
   );
+
+/******************************************************************************
+  reschedule_timer
+    change the time that a timer is scheduled to fire to a new time, or now.
+******************************************************************************/
+
+procedure reschedule_timer
+(
+    p_process_id    in flow_processes.prcs_id%type
+  , p_subflow_id    in flow_subflows.sbfl_id%type
+  , p_step_key      in flow_subflows.sbfl_step_key%type default null
+  , p_is_immediate  in boolean default false
+  , p_new_timestamp in flow_timers.timr_start_on%type default null
+  , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+);
+
 
 /******************************************************************************
   expire_timer

--- a/src/views/engine-app/flow_p0008_subflows_vw.sql
+++ b/src/views/engine-app/flow_p0008_subflows_vw.sql
@@ -19,6 +19,7 @@ as
              when 'waiting for timer' then 'fa fa-clock-o'
              when 'waiting for event' then 'fa fa-hand-stop-o'
          end as sbfl_status_icon
+       , sbfl.timr_start_on as sbfl_timr_start_on
        , sbfl.sbfl_current_lane_name as sbfl_current_lane
        , sbfl.sbfl_reservation
        , null as actions   

--- a/src/views/flow_subflows_vw.sql
+++ b/src/views/flow_subflows_vw.sql
@@ -28,6 +28,10 @@ as
         , sbfl.sbfl_reservation
         , objt_curr.objt_id as sbfl_current_objt_id
         , prcs.prcs_init_ts as sbfl_prcs_init_ts
+        , case sbfl_status 
+          when 'waiting for timer' then timr_start_on
+          else null
+          end as timr_start_on
      from flow_subflows sbfl
      join flow_processes prcs
        on prcs.prcs_id = sbfl.sbfl_prcs_id
@@ -47,5 +51,8 @@ left join flow_objects lane
        on objt_curr.objt_objt_lane_id = lane.objt_id
      join flow_diagrams dgrm 
        on dgrm.dgrm_id = prcs.prcs_dgrm_id
+left join flow_timers timr
+       on timr.timr_prcs_id = sbfl.sbfl_prcs_id
+      and timr.timr_sbfl_id = sbfl.sbfl_id
 with read only
 ;


### PR DESCRIPTION
Timer changes complete - ready for integration and testing
- adds flow_api_pkg.flow_reschedule_timer API call
- changes maxRepeats to maxRuns for consistency across ISO and Oracle cycle timers
- adds Oracle Duration YM as well as DS interval
- allows substitutions