### PR TITLE
Issues/issue 384

### DIFF
--- a/docs/AboutSubflows.md
+++ b/docs/AboutSubflows.md
@@ -48,6 +48,12 @@ Unless the subflow reaches a Gateway or an Event, the subflow progresses from ob
 
 As it progresses, the subflow's current object and last completed object are updated.
 
+#### Step Keys🆕
+
+A new feature introduced in v22.1 is Subflow Step Keys.  If enabled, the Flows for APEX engine generates a **Step Key** for each process step.  When a user wants to perform a step operation, they must supply the correct step key to the engine for the step operation to be performed.  This prevents more than one user trying to make the same step transition, and by mistake, moving the process forward 2 steps.  The first user will be able to make his step operation and move the process forward one step;  the second user will now be supplying an incorrect key for the new step, and so his operation will (correctly) fail.
+
+Step Keys should be enabled for all new projects, and any legacy applications built with v21 or earlier should adopt Step Keys in their next update.
+
 #### Action at an opening Exclusive Gateway
 
 An opening Exclusive Gateway acts as a decision point, from which the process continues on just one forward path.
@@ -107,6 +113,8 @@ If a sub process itself contains a sub-process object, the same process is repea
 
 If a subflow reaches an object with an attached timer -- such as a Timer Start Event or a Timer Intermediate Catch Event -- the subflow is given a status of `waiting for timer` until the timer has expired and the process can continue, which it does with a status of `running`.
 
+If the timer is a Repeating or Cycle Timer, it can fire multiple times, optionally up to a maximum number of runs.  Each time the timer fires, it will first check if it needs to reschedule another repeat / cycle, before executing the forward path.  If another cycle is required, it will create a new subflow for the next cycle, and set a timer on that subflow at the current time plus the specified cycle interval.
+
 #### Action at an Event Based Gateway
 
 An Event Based Gateway is a decision / gateway event where the single forward path is chosen based on which event occurs first.  Once an event occurs on one of the possible forward paths, all other paths are terminated and the flow continues forward on the one chosen path.
@@ -150,6 +158,7 @@ Timer Non-Interrupting Boundary Event.  When an object has an attached non-inter
 
 - If the parent object completes before the timer fires, the timer and its subflow is deleted before the next object on the subflow becomes current.
 - If the timer fires while the parent is still the current object on its subflow, the forked subflow proceeds to its next object.  If the parent then proceeds on its subflow, the forked boundary event subflow continues until it completes.
+- Timer non-interrupting boundary events can be defined repeating or cycle timers; If so, the engine will create a new subflow for the next run of the timer and set a timer on it, before moving forwards on the forked boundary event subflow.
 
 Non-Timer Non-Interrupting Boundary Events.  For example, a non-interrupting escalation boundary event.  These boundary events only fork off a new subflow if the relevant event event fires.  For example, if a sub process had an attached Non-Interrupting Escalation Boundary Event, the escalation subflow is only created if an escalation event is fired from inside the sub process, which is then caught by the matching boundary event.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,7 @@ Flows for APEX is based on version 2.0 of BPMN, released in January 2011.  BPMN 
 
 Working through the Flows for APEX tutorial workflows is one way to get started.  They are included in the distributed product, and also hosted on apex.oracle.com (see: https://bit.ly/flowsforapex).
 
-For deeper understanding of BPMN, we'd recommend the following boks:
+For deeper understanding of BPMN, we'd recommend the following books:
 
 * Real-Life BPMN (4th ed): Includes an Introduction to DMN* by Jakob Freund and Bernd Rücker.  Available in hardcopy or on kindle from Amazon.  (English and German versions available).
 * BPMN Method and Style (2nd ed): by Bruce Silver.  Available in hardcopy or on kindle from Amazon.
@@ -25,7 +25,7 @@ Contact the Flows for APEX team if you want to arrange training or consulting su
 
 Database:  Minimum 12.2
 
-APEX: Minimum 20.1.    (We haven't tested on 19.1, and haven't checked whether we use any API's not present before 20.1).
+APEX: Minimum 20.1.   
 
 #### Could this be used as a replacement for the old Oracle Workflow?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,10 @@ Flows for APEX is based on version 2.0 of BPMN, released in January 2011.  BPMN 
 
 Working through the Flows for APEX tutorial workflows is one way to get started.  They are included in the distributed product, and also hosted on apex.oracle.com (see: https://bit.ly/flowsforapex).
 
-For deeper understanding of BPMN, we'd recommend *Real-Life BPMN (4th ed): Includes an Introduction to DMN* by Jakob Freund and Bernd Rücker.  available is hardcopy or on kindle from Amazon.  (English and German versions available).
+For deeper understanding of BPMN, we'd recommend the following boks:
+
+* Real-Life BPMN (4th ed): Includes an Introduction to DMN* by Jakob Freund and Bernd Rücker.  Available in hardcopy or on kindle from Amazon.  (English and German versions available).
+* BPMN Method and Style (2nd ed): by Bruce Silver.  Available in hardcopy or on kindle from Amazon.
 
 Contact the Flows for APEX team if you want to arrange training or consulting support for your Flows for APEX development project.  These can be arranged online or, once the pandemic situation permits, on-site.
 

--- a/docs/FlowsforAPEX_PLSQL_API.md
+++ b/docs/FlowsforAPEX_PLSQL_API.md
@@ -41,7 +41,7 @@ These comprise:
 
 ### Instance Variable (Process Variable) Operations
 
-Process Variable operations are used to set, get, and delete Process Variables.
+Process Variable operations are used to set, get, and delete Process Variables.  You can also get the type of a Process Variable.
 
 Process Variable operations are contained in the PL/SQL package `flow_process_vars`.
 

--- a/docs/behaviourOfBoundaryEventsInSubProcesses.md
+++ b/docs/behaviourOfBoundaryEventsInSubProcesses.md
@@ -38,7 +38,7 @@ Behavior is:
 Timer Boundary Events can be *interrupting* or *non-interrupting*.
 
 - An *interrupting timer boundary event* can be used to create a "timeout" after a specified time period or at a specified time.  When the timer fires at the specified time, processing of the sub-process and any child sub-processes is interrupted.  The parent subflow continues along the route forward from the interrupting timer boundary event.  You can only have one interrupting timer boundary event attached to an object.
-- A *non-interrupting timer boundary event* can be used to create a reminder after the process step has been started for a specified time period, or at a specified time.  When the timer fires, processing of the parent task continues.  In addition, a new subflow processes tasks on the reminder route.  You can have one or more interrupting timer boundary events attached to an object, firing at different times or triggering different process tasks.
+- A *non-interrupting timer boundary event* can be used to create a reminder after the process step has been started for a specified time period, or at a specified time.  When the timer fires, processing of the parent task continues.  In addition, a new subflow processes tasks on the reminder route.  You can have one or more interrupting timer boundary events attached to an object, firing at different times or triggering different process tasks.  These can also be defined as Cycle Timers, where they repeat at a defined interval, for example, to send a reminder every week to a user for an overdue task.
 
 A more complex example of how these can be used together is shown below.
 

--- a/docs/configurationParameters.md
+++ b/docs/configurationParameters.md
@@ -8,7 +8,6 @@ Event logging is currently designed to be configurable, so that an installation 
 
 Logging is configured using Flows for APEX configuration parameters, which are stored in the FLOW_CONFIGURATION table.
 
-
 | parameter           | possible values | behavior                                                                                                                                                                                                   | default |
 | --------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
 | logging_level       | off             | logging is disabled                                                                                                                                                                                        |         |
@@ -24,9 +23,20 @@ Logging is configured using Flows for APEX configuration parameters, which are s
 
 ### Configuring Diagram Versioning
 
-
 | parameter       | possible values | behavior                                                                                                                    | default |
 | ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- |
 | engine_app_mode | production      | versioning controls are strictly enforced.`released` models cannot be edited and resaved, except by creating a new version. | yes     |
 |                 | development     | versioning controls are not strictly enforced. diagrams in`released` status can be edited and re-saved.                     |         |
 |                 |                 |                                                                                                                             |         |
+
+### General System Configuration
+
+| parameter                 | possible values                                                                                                                                                                                   | behavior                                                                                                                                                                                        | default                   |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| duplicate_step_prevention | strict                                                                                                                                                                                            | requires step keys to be provided on all step operations, thus preventing multiple users from attempting to make the same step transition but instead moving the process forward multiple steps | yes (new installations)   |
+|                           | legacy                                                                                                                                                                                            | allows null step keys.  Incorrect step keys will still cause an error.  Only use this until you migrate your v21 and earlier apps to use Step Keys                                              | only for migrated systems |
+| version_initial_installed | | records the version first installed (do not change)                                                                                                                                               |                                                                                                                                                                                                 |                           |
+| version_now_installed  |   | records the current version installed, after any migrations have occured                                                                                                                          |                                                                                                                                                                                                 |                           |
+| default_workspace       |  | should be set to your default APEX workspace used for Flows for APEX.  This is used as a last-resort for scriptTasks and serviceTasks when creating an APEX session or looking for mail templates |                                                                                                                                                                                                 |                           |
+| default_email_sender     |  | should be set to your default email sender, in case outbound mail serviceTasks do not have a sender defined                                                                                       |                                                                                                                                                                                                 |                           |
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ The diagram below gives a full definition of the BPMN syntax supported in the cu
 - [The Flows for APEX PL/SQL API](FlowsforAPEX_PLSQL_API.md)
 - [The Process Variable System](processVariables.md)
 - [Declarative Process Variable Expressions](variableExpressions.md)🆕
+- [Syntax and Allowed Substitutions for Timer Specifications](specifyingTimers.md)🆕
 - [Event Logging and Audit Trail](eventLoggingAndAuditing.md)🆕
 - [Flows for APEX Configuration Parameters](configurationParameters.md)🆕
 

--- a/docs/processVariables.md
+++ b/docs/processVariables.md
@@ -19,6 +19,8 @@ Process variables are typed, and are based on Oracle datatypes.  Allowed types a
 - `date`
 - `clob`
 
+There is a function `flow_process_vars.get_var_type()` that returns the type of a process variable.
+
 #### Built-In Variables
 
 Flows for APEX instances contains one built-in process variable that is created for every Instance.
@@ -119,6 +121,6 @@ Process variables can be set or got inside a PL/SQL scriptTask
 or serviceTask procedure using the setters and getters above.
 [See doc](usingTasksToImplementYourProcess.md)
 
-Process variables can be substituted into the definition string for Timers.  [See doc](usingTimerEvents.md)
+Process variables can be substituted into the definition string for Timers.  [See doc](specifyingTimers.md)
 
 Your application can set and get process variables by calling the appropriate setters and getters, as required.

--- a/docs/reservations.md
+++ b/docs/reservations.md
@@ -1,25 +1,32 @@
 #### Multi User Pools and Task Reservation
 
-If you are using Flows for APEX for task orchestration or have an application where users are provided with a task inbox, all users who are serving a lane will see all of the current tasks in that lane.  
+If you are using Flows for APEX for task orchestration or have an application where users are provided with a task inbox, all users who are serving a lane will see all of the current tasks in that lane.
 *Task Reservation* provides a mechanism for users who are sharing a lane to record that they are working on a task, or intend to work on a task, so that other users don't also work on the same task.
 
-Tasks can be reserved, by calling the `flow_api_pkg.flow_reserve_step procedure`.  
-When you reserve a step, you supply a `reservation` as the `p_reservation` argument.  
+Tasks can be reserved, by calling the `flow_api_pkg.flow_reserve_step procedure`.
+When you reserve a step, you supply a `reservation` as the `p_reservation` argument.
 This would usually be set to the username of the user making the reservation - although an application might want to have some other scheme for reservation value.
 
 A task reservation can also be explicitly released by calling `flow_api_pkg.flow_release_step` procedure.
 
 Reservation only applies to the current step on a subflow, and is implicitly released when the step is completed and the process continues to the next step, i.e., when `flow_api_pkg.flow_complete_step` is called.
 
-Reservations are exposed to the application in flow_subflows_vw and flow_task_inbox_vw through the sbfl_reservation column.  
+Reservations are exposed to the application in flow_subflows_vw and flow_task_inbox_vw through the sbfl_reservation column.
 You can also see an example of how these could be used in an application by examining the subflows region on page 10 of the Flows for APEX core application.
 
 ![exposing reservations](images/reservationsUI.png "Exposing the Reservations in the application")
 
+### Building Reservations into your APEX application.
+
+Step Reservation, and Reservation Release, can be declaratively added to your APEX applicartion by use of the flow_instance_step_operations Plug-in.  This, like other Flows for APEX plugins, can be copied from the distributed Flows for APEX application.
+
 ### Reservations are Not a Security Mechanism
 
-The Flows For APEX Task Reservation is a light weight, convenience mechanism to signal to others that this task is reserved and will be worked on by the reserving user.  
-Out of the box, IT IS NOT A SECURITY MECHANISM that prevents unauthorized users from working on a task.  
+The Flows For APEX Task Reservation is a light weight, convenience mechanism to signal to others that this task is reserved and will be worked on by the reserving user.
+Out of the box, IT IS NOT A SECURITY MECHANISM that prevents unauthorized users from working on a task.
 **YOU SHOUD NOT RELY ON THIS MECHANISM TO CONTROL TASK AUTHORIZATION OR OTHER ACCESS CONTROL OBJECTIVES.**
 
 As part of your application design, you might want to wrap these procedures with your own application-specific controls to implement control on who can reserve (and for whom), and who can release reservations.
+
+Step Reservation and Release both require a Step Key to be provided from v22.1.
+

--- a/docs/specifyingTimers.md
+++ b/docs/specifyingTimers.md
@@ -1,0 +1,106 @@
+# Timer Syntax
+
+To define a Timer Event, first drag the Event onto your new process canvas.   Select the 'Change Type' spanner icon on the pop-up menu, and select Timer version of that from the menu.  To then specify the Timer Configuration, use the Properties Panel on the right of the screen.
+
+Timer definitions can be specified in the properties panel as a literal value, or can be specified using a process variable substitution.  Timers can be specified using ISO 8601 syntax, or using more familiar Oracle syntax.
+
+Under Timer, select the type of timer you want.  There are separate options for [ISO 8601](#ISO8601-Syntax) and [Oracle format Date and Interval](#Oracle-Syntax) specifications.
+
+In addition, Flows for APEX Process Variables can also be used as substitution parameters so that you can use a Process Variable to define a Timer syntax component.  Valid substitutions and the required format and typing are listed below.
+
+## ISO Syntax {#ISO8601-Syntax}
+
+Under Timer Definition, use the ISO 8601 format for the required time or interval, as below.  A good overview to ISO 8601 date/time format strings can be [found on Wikipedia. (click here)](https://en.wikipedia.com/wiki/ISO_8601)
+
+### ISO 8601 Date
+
+Specify a specific date and time for the process to start.  Date/Time components are listed from broader to more specific, with date components separated by dash ('-') characters, time components separated by colon (':') characters, and an upper-case 'T' character  separating the date from the time components.  All components used must be zero-padded.
+If only a Time component is provided, the event will be scheduled for the next time the specified time occurs.  So, for example, if the given string was `T14:00`, and the current time was 09:00, the event would be scheduled for 14:00 (2PM) today; if the time is after 14:00, the event will be scheduled for 14:00 (2PM) tomorrow.
+
+- Some examples:
+
+```
+2007-04-05T14:30
+2021-11-23T07:15:23
+T14:30:15    represents the next occurring 14:00:15 today or tomorrow.
+```
+
+- Allowed Substitutions:  ISO Dates can be substituted with Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - Date-typed Process Variable.  The date-typed process variable must contain the date/time that the event should fire.
+  - Varchar2-typed Process Variable.  The varchar2-typed process variable must contain a valid Oracle-date using a format mask of `YYYY-MM-DD HH24:MI:SS`.  The Time zone used will be that of the database server.
+
+### ISO 8601 Duration / Period
+
+Specifies a delay from the current time or the process to start, using an [ISO 8601 duration](https://en.wikipedia.com/wiki/ISO_8601#Durations) string.  This always starts with an upper-case 'P'.
+
+- Some examples:
+
+```
+P3Y6M4DT12H30M5S" represents a duration of three years, six months, four days,
+twelve hours, thirty minutes, and five seconds.
+P3M               represents 3 months.
+PT5M              represents 5 minutes.
+PT30S             represents 30 seconds.
+```
+
+- Allowed Substitutions:  ISO Durations can be substituted with Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - Varchar2-typed Process Variable.  The varchar2-typed process variable must contain a valid ISO 8601 Duration / Period using a format mask of `P(yyY)(mmM)(ddD)T(hhH)(mmM)(ssS)`.  Each bracketed component is optional.
+
+### ISO 8601 Repeating Duration / Cycle Timers
+
+Specifies the date/time for an initial run and then defined intervals for repetition.  Repeating timers are newly supported in Flows for APEX from v21.2 onwards.  The Repeating Period uses a Repeat Specification followed by the Period Specification, above.
+The Repeat Specification is of the form `Rnn/` where R is an upper-case 'R' character to denote a 'Repeat', 'nn' is the number of times the timer should fire, and the slash character ('/') is the separator between the Repeat specification and the Period specification.  If 'nn' is omitted or equals '-1', the timer will fire continuously until cancelled.
+
+- Some examples:
+
+```
+R5/P5D          represents 5 events, starting in 5 Days and repeating every 5 days.
+R10/P1H20M      represents 10 events, starting in 80 minutes and repeating every 80 minutes.
+R/P20S          represents an unlimited number of events, repeating every 20 seconds.
+R-1/P6H         represents an unlimited number of events, repeating every 6 hours.
+```
+
+- Allowed Substitutions:  ISO Durations can be substituted with Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - Varchar2-typed Process Variable.  The varchar2-typed process variable must contain a valid ISO 8601 Repeating Duration / Cycle Timer (as described above) using a format mask of `Rnn/P(yyY)(mmM)(ddD)T(hhH)(mmM)(ssS)`.  Each bracketed component is optional.
+
+## Oracle-format Date and Interval Syntax. {#Oracle-Syntax}
+
+From v22.1, you can now also use the Oracle format Date and Interval specifications, and for Dates you can also specify the Format Mask.
+
+For more information on Oracle date / time formats, please see the Oracle SQL Language Reference Manual.
+
+### Oracle Dates
+
+Oracle Dates can be specified as an Oracle-format date and an associated Oracle date format mask.
+
+- Allowed Substitutions:  Oracle Dates can be substituted with Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - Date-typed Process Variable.  The date-typed process variable must contain the date/time that the event should fire.
+  - Varchar2-typed Process Variable.  The varchar2-typed process variable must contain a valid Oracle-date using a format mask of `YYYY-MM-DD HH24:MI:SS`.  The Time zone used will be that of the database server.
+
+### Oracle Duration
+
+Oracle Durations are specified with two separate components - a Years-Months Interval and a Days-Seconds Interval.  Both must be supplied as a varchar2 string in the required format.  The Timer duration is the sum of both components.
+
+- Interval Years to Months:   The Interval Years-to-Months component is supplied in format `YY-MM`.
+- Interval Days(3) to Seconds: The Interval Days-to-Seconds is supplied in the format `DDD HH24:MI:SS`.
+- Allowed Substitutions:  Each component of an Oracle Duration can optionally be substituted with a Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - For the Interval YM Component:   A varchar2-typed Process Variable containing a valid Oracle Interval YM using a format mask of `YY-MM`.
+  - For the Interval DS Component:   A varchar2-typed Process Variable containing a valid Oracle Interval DS using a format mask of `DDD HH24:MI:SS`.
+
+### Oracle Cycle Timer
+
+Oracle Cycle Timers are specified as three separate components:
+
+- Interval to First Firing: The Interval Days(3)-to-Seconds is supplied in the format `DDD HH24:MI:SS`.
+- Interval between Repeat Firings: The Interval Days-to-Seconds is supplied in the format `DDD HH24:MI:SS`.
+- Maximum Number of Runs:  The maximum number of times the timer will fire, in format `nnn`.  If omitted, the timer will continue to fire until cancelled.
+- Allowed Substitutions:  Each component of an Oracle Cycle can optionally be substituted with a Flows for APEX Process Variables using the `&F4A$proc_var_name.` substitution syntax as follows:
+
+  - For the Interval to First Firing:   A varchar2-typed Process Variable containing a valid Oracle Interval-DS using a format mask of `DDD HH24:MI:SS`.
+  - For the Interval between Repeat Firings:   A varchar2-typed Process Variable containing a valid Oracle Interval-DS using a format mask of `DDD HH24:MI:SS`.
+  - For the Maximum Number of Runs: A varchar2-typed Process Variable containing a valid number in format `nnnn`.

--- a/docs/usingTasksToImplementYourProcess.md
+++ b/docs/usingTasksToImplementYourProcess.md
@@ -25,8 +25,8 @@ Item Values contains a comma-separated list of values to be supplied.  The follo
   &F4A$ is required to be upper case.
   Note the trailing period '.'.
 - Flows for APEX Pseudo Variables.
-  The current Process ID and Subflow ID are also available as pseudo variables.
-  These are specified as `&F4A$PROCESS_ID.` and `&F4A$SUBFLOW_ID.` respectively.
+  The current Process ID, Subflow ID and Step Key for the current task are also available as pseudo variables.
+  These are specified as `&F4A$PROCESS_ID.` , `&F4A$SUBFLOW_ID.` and `&F4A$STEP_KEY.` respectively.
 
 Note that you will need to pass the Process_ID and Subflow_ID to a page if you want the page to initiate a flow_step_complete when it is processed.
 
@@ -42,10 +42,11 @@ Process variables and pseudo variables are available inside your PL/SQL procedur
   Process variables can be retrieved and used inside your procedure, using the flow_process_vars setters and getters.
 - Flows for APEX Pseudo Variables.
   Process ID and Subflow ID are available inside your procedure using following function calls
-  
+
   ```sql
   flow_global.process_id
   flow_global.subflow_id
+  flow_global.step_key
   ```
 
 In earlier versions of Flows for APEX, prior to v21.1, you could have done this using the syntax flow_plsql_runner_pkg.g_current_prcs_id, which is now deprecated.
@@ -68,4 +69,3 @@ Currently serviceTask is used to send email using the same mechanism as scriptTa
 ###### 5. bpmn:manualTasks - for non-IT tasks
 
 manualTasks do not currently have any special functionality and currently behave like a standard bpmn:task objects.
-

--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -332,9 +332,37 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-set-error',
 'en',
-'Error %0 process variable %1 for process id %2.'
+'Error creating process variable %0 for process id %1.'
 );
  
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-get-error',
+'en',
+'Error getting process variable %0 for process id %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-update-error',
+'en',
+'Error updating process variable %0 for process id %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-delete-error',
+'en',
+'Error deleting process variable %0 for process id %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-lock-error',
+'en',
+'Error locking process variable %0 for process id %1.'
+);
+
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var_exp_datatype',

--- a/src/data/install_engine_messages_fr.sql
+++ b/src/data/install_engine_messages_fr.sql
@@ -1,4 +1,4 @@
-PROMPT >> Loading Exported Messages
+bhnuyPROMPT >> Loading Exported Messages
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'ITE-unsupported-type',
@@ -330,9 +330,37 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-set-error',
 'fr',
-'Erreur %0 variable de processus %1 pour l''ID de processus %2.'
+'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
 );
  
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-get-error',
+'en',
+'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-update-error',
+'en',
+'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-delete-error',
+'en',
+'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+);
+ 
+insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+ values (
+'var-lock-error',
+'en',
+'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+); 
+
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var_exp_datatype',

--- a/src/data/install_engine_messages_fr.sql
+++ b/src/data/install_engine_messages_fr.sql
@@ -330,35 +330,35 @@ insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-set-error',
 'fr',
-'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+'Erreur de création de la variable de processus %0 pour l''ID de processus %1.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-get-error',
 'en',
-'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+'Erreur de récupération de la variable de processus %0 pour l''ID de processus %1.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-update-error',
 'en',
-'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+'Erreur de mise à jour de la variable de processus %0 pour l''ID de processus %1.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-delete-error',
 'en',
-'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+'Erreur de suppression de la variable de processus %0 pour l''ID de processus %1.'
 );
  
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
  values (
 'var-lock-error',
 'en',
-'Erreur XXXX  variable de processus %0 pour l''ID de processus %1.'
+'Erreur de verrouillage de la variable de processus %0 pour l''ID de processus %1.'
 ); 
 
 insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )

--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -200,8 +200,9 @@ as
   is 
   begin 
     flow_globals.set_context
-    ( pi_prcs_id => p_process_id
-    , pi_sbfl_id => p_subflow_id
+    ( pi_prcs_id  => p_process_id
+    , pi_sbfl_id  => p_subflow_id
+    , pi_step_key => p_step_key
     );
     flow_engine.restart_step
     ( p_process_id => p_process_id
@@ -220,8 +221,9 @@ as
   is 
   begin
     flow_globals.set_context
-    ( pi_prcs_id => p_process_id
-    , pi_sbfl_id => p_subflow_id
+    ( pi_prcs_id  => p_process_id
+    , pi_sbfl_id  => p_subflow_id
+    , pi_step_key => p_step_key
     );
     flow_engine.flow_complete_step
     ( p_process_id => p_process_id

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -805,8 +805,9 @@ begin
   l_dgrm_id := flow_engine_util.get_dgrm_id (p_prcs_id => p_process_id);
   -- set context for scripts and variable expressions
   flow_globals.set_context
-  ( pi_prcs_id => p_process_id
-  , pi_sbfl_id => p_subflow_id
+  ( pi_prcs_id  => p_process_id
+  , pi_sbfl_id  => p_subflow_id
+  , pi_step_key => p_step_key
   );
   flow_globals.set_is_recursive_step (p_is_recursive_step => true);
   -- initialise step_had_error flag

--- a/src/plsql/flow_globals.pkb
+++ b/src/plsql/flow_globals.pkb
@@ -12,14 +12,15 @@ as
 
 
   procedure set_context
-  ( pi_prcs_id in flow_processes.prcs_id%type
-  , pi_sbfl_id in flow_subflows.sbfl_id%type default null
+  ( pi_prcs_id  in flow_processes.prcs_id%type
+  , pi_sbfl_id  in flow_subflows.sbfl_id%type default null
+  , pi_step_key in flow_subflows.sbfl_step_key%type default null
   )
   is
   begin 
     process_id := pi_prcs_id;
     subflow_id := pi_sbfl_id;
-  
+    step_key   := pi_step_key;
   end set_context;
 
   procedure set_step_error

--- a/src/plsql/flow_globals.pks
+++ b/src/plsql/flow_globals.pks
@@ -3,10 +3,12 @@ as
 
   process_id flow_processes.prcs_id%type;
   subflow_id flow_subflows.sbfl_id%type;
+  step_key   flow_subflows.sbfl_step_key%type;
 
   procedure set_context
-  ( pi_prcs_id in flow_processes.prcs_id%type
-  , pi_sbfl_id in flow_subflows.sbfl_id%type default null
+  ( pi_prcs_id  in flow_processes.prcs_id%type
+  , pi_sbfl_id  in flow_subflows.sbfl_id%type default null
+  , pi_step_key in flow_subflows.sbfl_step_key%type default null
   );
 
   procedure set_step_error

--- a/src/plsql/flow_plsql_runner_pkg.pkb
+++ b/src/plsql/flow_plsql_runner_pkg.pkb
@@ -51,9 +51,10 @@ as
 
   procedure run_task_script
   (
-    pi_prcs_id in flow_processes.prcs_id%type
-  , pi_sbfl_id in flow_subflows.sbfl_id%type
-  , pi_objt_id in flow_objects.objt_id%type
+    pi_prcs_id  in flow_processes.prcs_id%type
+  , pi_sbfl_id  in flow_subflows.sbfl_id%type
+  , pi_objt_id  in flow_objects.objt_id%type
+  , pi_step_key in flow_subflows.sbfl_step_key%type default null
   )
   as
     l_use_apex_exec boolean := false;
@@ -67,10 +68,10 @@ as
     , 'pi_objt_id', pi_objt_id
     );
 
-    --init_globals( pi_prcs_id => pi_prcs_id, pi_sbfl_id => pi_sbfl_id );
     flow_globals.set_context 
-    ( pi_prcs_id => pi_prcs_id
-    , pi_sbfl_id => pi_sbfl_id 
+    ( pi_prcs_id  => pi_prcs_id
+    , pi_sbfl_id  => pi_sbfl_id 
+    , pi_step_key => pi_step_key
     );
 
     for rec in ( select obat.obat_key

--- a/src/plsql/flow_plsql_runner_pkg.pks
+++ b/src/plsql/flow_plsql_runner_pkg.pks
@@ -18,9 +18,10 @@ as
   
   procedure run_task_script
   (
-    pi_prcs_id in flow_processes.prcs_id%type
-  , pi_sbfl_id in flow_subflows.sbfl_id%type
-  , pi_objt_id in flow_objects.objt_id%type
+    pi_prcs_id  in flow_processes.prcs_id%type
+  , pi_sbfl_id  in flow_subflows.sbfl_id%type
+  , pi_objt_id  in flow_objects.objt_id%type
+  , pi_step_key in flow_subflows.sbfl_step_key%type default null
   );
 
 end flow_plsql_runner_pkg;

--- a/src/plsql/flow_process_vars.pkb
+++ b/src/plsql/flow_process_vars.pkb
@@ -29,7 +29,7 @@ begin
       );      
   exception
     when dup_val_on_index then
-      l_action := 'updating';
+      l_action := 'var-update-error';
       update flow_process_variables prov 
          set prov.prov_var_vc2 = pi_vc2_value
        where prov.prov_prcs_id = pi_prcs_id
@@ -38,7 +38,7 @@ begin
            ;
     when others
     then
-      l_action := 'creating';
+      l_action := 'var-set-error';
       raise;
   end;
   flow_logging.log_variable_event
@@ -56,12 +56,12 @@ exception
     flow_errors.handle_instance_error
     ( pi_prcs_id        => pi_prcs_id
     , pi_sbfl_id        => pi_sbfl_id
-    , pi_message_key    => 'var-set-error'
-    , p0 => l_action         
-    , p1 => pi_var_name
-    , p2 => pi_prcs_id
+    , pi_message_key    => l_action
+    , p0 => pi_var_name
+    , p1 => pi_prcs_id
     );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-set-error' || 'Error setting process variable %0 for process id %1.'
+    -- $F4AMESSAGE 'var-update-error' || 'Error updating process variable %0 for process id %1.'   
 end set_var;
 
 procedure set_var
@@ -89,7 +89,7 @@ begin
       );
   exception
     when dup_val_on_index then
-      l_action := 'updating';
+      l_action := 'var-update-error';
       update flow_process_variables prov 
          set prov.prov_var_num = pi_num_value
        where prov.prov_prcs_id = pi_prcs_id
@@ -98,7 +98,7 @@ begin
            ;
     when others
     then
-      l_action := 'creating';
+      l_action := 'var-set-error';
       raise;
   end;
   flow_logging.log_variable_event
@@ -116,12 +116,12 @@ exception
     flow_errors.handle_instance_error
     ( pi_prcs_id        => pi_prcs_id
     , pi_sbfl_id        => pi_sbfl_id
-    , pi_message_key    => 'var-set-error'
-    , p0 => l_action         
-    , p1 => pi_var_name
-    , p2 => pi_prcs_id
+    , pi_message_key    => l_action         
+    , p0 => pi_var_name
+    , p1 => pi_prcs_id
     );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-set-error' || 'Error setting process variable %0 for process id %1.'
+    -- $F4AMESSAGE 'var-update-error' || 'Error updating process variable %0 for process id %1.'   
 end set_var;
 
 procedure set_var
@@ -149,7 +149,7 @@ begin
       );
   exception
     when dup_val_on_index then
-      l_action := 'updating';
+      l_action := 'var-update-error';
       update flow_process_variables prov 
          set prov.prov_var_date = pi_date_value
        where prov.prov_prcs_id = pi_prcs_id
@@ -158,7 +158,7 @@ begin
            ;
     when others
     then
-      l_action := 'creating';
+      l_action := 'var-set-error';
       raise;
   end;
   flow_logging.log_variable_event
@@ -176,12 +176,12 @@ exception
     flow_errors.handle_instance_error
     ( pi_prcs_id        => pi_prcs_id
     , pi_sbfl_id        => pi_sbfl_id
-    , pi_message_key    => 'var-set-error'
-    , p0 => l_action         
-    , p1 => pi_var_name
-    , p2 => pi_prcs_id
+    , pi_message_key    => l_action         
+    , p0 => pi_var_name
+    , p1 => pi_prcs_id
     );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-set-error' || 'Error setting process variable %0 for process id %1.'
+    -- $F4AMESSAGE 'var-update-error' || 'Error updating process variable %0 for process id %1.'   
 end set_var;
 
 procedure set_var
@@ -217,7 +217,7 @@ begin
            ;
     when others
     then
-      l_action := 'creating';
+      l_action := 'var-set-error';
       raise;
   end;
   flow_logging.log_variable_event
@@ -235,12 +235,11 @@ exception
     flow_errors.handle_instance_error
     ( pi_prcs_id        => pi_prcs_id
     , pi_sbfl_id        => pi_sbfl_id
-    , pi_message_key    => 'var-set-error'
-    , p0 => l_action         
-    , p1 => pi_var_name
-    , p2 => pi_prcs_id
+    , pi_message_key    => l_action         
+    , p0 => pi_var_name
+    , p1 => pi_prcs_id
     );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-set-error' || 'Error setting process variable %0 for process id %1.'
 end set_var;
 
 -- getters return
@@ -265,12 +264,11 @@ exception
     if pi_exception_on_null then
       flow_errors.handle_instance_error
       ( pi_prcs_id        => pi_prcs_id
-      , pi_message_key    => 'var-set-error'
-      , p0 => 'getting'       
-      , p1 => pi_var_name
-      , p2 => pi_prcs_id
+      , pi_message_key    => 'var-get-error'      
+      , p0 => pi_var_name
+      , p1 => pi_prcs_id
       );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-get-error' || 'Error getting process variable %0 for process id %1.'
     else
       return null;
     end if;
@@ -296,12 +294,11 @@ exception
     if pi_exception_on_null then
       flow_errors.handle_instance_error
       ( pi_prcs_id        => pi_prcs_id
-      , pi_message_key    => 'var-set-error'
-      , p0 => 'getting'         
-      , p1 => pi_var_name
-      , p2 => pi_prcs_id
+      , pi_message_key    => 'var-get-error'      
+      , p0 => pi_var_name
+      , p1 => pi_prcs_id
       );
-      -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+      -- $F4AMESSAGE 'var-get-error' || 'Error getting process variable %0 for process id %1.'
     else
       return null;
     end if;
@@ -327,12 +324,11 @@ exception
     if pi_exception_on_null then
       flow_errors.handle_instance_error
       ( pi_prcs_id        => pi_prcs_id
-      , pi_message_key    => 'var-set-error'
-      , p0 => 'getting'        
-      , p1 => pi_var_name
-      , p2 => pi_prcs_id
+      , pi_message_key    => 'var-get-error'      
+      , p0 => pi_var_name
+      , p1 => pi_prcs_id
       );
-      -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+      -- $F4AMESSAGE 'var-get-error' || 'Error getting process variable %0 for process id %1.'
     else
       return null;
     end if;
@@ -358,12 +354,11 @@ exception
     if pi_exception_on_null then
       flow_errors.handle_instance_error
       ( pi_prcs_id        => pi_prcs_id
-      , pi_message_key    => 'var-set-error'
-      , p0 => 'getting'       
-      , p1 => pi_var_name
-      , p2 => pi_prcs_id
+      , pi_message_key    => 'var-get-error'      
+      , p0 => pi_var_name
+      , p1 => pi_prcs_id
       );
-      -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+      -- $F4AMESSAGE 'var-get-error' || 'Error getting process variable %0 for process id %1.'
     else
       return null;
     end if;
@@ -431,21 +426,19 @@ exception
   when  no_data_found then
       flow_errors.handle_instance_error
       ( pi_prcs_id        => pi_prcs_id
-      , pi_message_key    => 'var-set-error'
-      , p0 => 'deleting'         
-      , p1 => pi_var_name
-      , p2 => pi_prcs_id
+      , pi_message_key    => 'var-delete-error'        
+      , p0 => pi_var_name
+      , p1 => pi_prcs_id
       );
-      -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+      -- $F4AMESSAGE 'var-delete-error' || 'Error deleting process variable %0 for process id %1.'
   when lock_timeout then
     flow_errors.handle_instance_error
     ( pi_prcs_id        => pi_prcs_id
-    , pi_message_key    => 'var-set-error'
-    , p0 => 'locking'        
-    , p1 => pi_var_name
-    , p2 => pi_prcs_id
+    , pi_message_key    => 'var-lock-error'       
+    , p0 => pi_var_name
+    , p1 => pi_prcs_id
     );
-    -- $F4AMESSAGE 'var-set-error' || 'Error %0 process variable %1 for process id %1.'
+    -- $F4AMESSAGE 'var-lock-error' || 'Error locking process variable %0 for process id %1.'
 end delete_var;
 
 -- special cases / built-in standard variables

--- a/src/plsql/flow_tasks.pkb
+++ b/src/plsql/flow_tasks.pkb
@@ -149,9 +149,10 @@ as
     );
     
     flow_plsql_runner_pkg.run_task_script(
-      pi_prcs_id => p_sbfl_info.sbfl_prcs_id
-    , pi_sbfl_id => p_sbfl_info.sbfl_id
-    , pi_objt_id => p_step_info.target_objt_id
+      pi_prcs_id  => p_sbfl_info.sbfl_prcs_id
+    , pi_sbfl_id  => p_sbfl_info.sbfl_id
+    , pi_objt_id  => p_step_info.target_objt_id
+    , pi_step_key => p_sbfl_info.sbfl_step_key
     );
 
     flow_engine.flow_complete_step 
@@ -189,7 +190,7 @@ as
       -- $F4AMESSAGE 'plsql_script_requested_stop' || 'Process %0: ScriptTask %1 requested processing stop - see event log.'
   end process_scriptTask;
 
-  procedure process_serviceTask --- note NOT CURRENTLY BEING USED FOR SERVICETASKS - USING process_scriptTask
+  procedure process_serviceTask 
   ( p_sbfl_info     in flow_subflows%rowtype
   , p_step_info     in flow_types_pkg.flow_step_info
   )
@@ -199,7 +200,7 @@ as
     ( 'process_serviceTask'
     , 'p_step_info.target_objt_tag', p_step_info.target_objt_tag 
     );
-    -- current implementation is limited to one serviceTask type, which is for apex message template sent from user defined PL/SQL script
+  
     -- future serviceTask types could include text message, tweet, AOP document via email, etc.
     -- current implementation is limited to synchronous email send (i.e., email sent as part of Flows for APEX process).
     -- future implementations could include async serviceTask, where message generation is queued, or non-email services
@@ -214,9 +215,10 @@ as
     case get_task_type( p_step_info.target_objt_id )
       when flow_constants_pkg.gc_apex_task_execute_plsql then
         flow_plsql_runner_pkg.run_task_script
-        ( pi_prcs_id => p_sbfl_info.sbfl_prcs_id
-        , pi_sbfl_id => p_sbfl_info.sbfl_id
-        , pi_objt_id => p_step_info.target_objt_id
+        ( pi_prcs_id  => p_sbfl_info.sbfl_prcs_id
+        , pi_sbfl_id  => p_sbfl_info.sbfl_id
+        , pi_objt_id  => p_step_info.target_objt_id
+        , pi_step_key => p_sbfl_info.sbfl_step_key
         );
       when flow_constants_pkg.gc_apex_servicetask_send_mail then
         flow_services.send_email


### PR DESCRIPTION
Fixes #384 - non-translatable error messages in flow_process_vars
Fixes #385 - makes available step_key in flow_globals and as a substitution parameter
Adds doc for new timer syntax & general other V21.2 features / changes