### PR TITLE
fix #846 - correct instance progress view

### DIFF
--- a/src/views/engine-app/flow_p0019_vw.sql
+++ b/src/views/engine-app/flow_p0019_vw.sql
@@ -2,31 +2,42 @@ create or replace view flow_p0019_vw as
 with sbfl_counts as (
     select p.prcs_dgrm_id dgrm_id, 
            s.sbfl_current steps, 
-           s.sbfl_status, 
+           case s.sbfl_status
+             when 'error'     then 'error'
+             when 'suspended' then 'suspended'
+             else                  'running'
+           end as badge_category,
            count(s.sbfl_id) numprocs
     from   flow_subflows s
     join   flow_processes p
     on     s.sbfl_prcs_id = p.prcs_id
     where  p.prcs_status in ('error', 'suspended', 'running')
-    and    s.sbfl_status in ('error', 'suspended', 'running', 'waiting for message')
-    group  by p.prcs_dgrm_id, s.sbfl_current, s.sbfl_status
+    and    s.sbfl_status in ('error', 'suspended', 'running', 'waiting for message', 'waiting for approval', 
+                             'waiting at gateway', 'waiting for timer', 'in subprocess','in call activity', 'iterating')
+    group  by p.prcs_dgrm_id
+            , s.sbfl_current
+            , case s.sbfl_status
+                when 'error'     then 'error'
+                when 'suspended' then 'suspended'
+                else                  'running'
+              end
 ),
 step_labels as (
     select sc.dgrm_id,
            sc.steps,
            json_arrayagg(
              json_object(
-               key 'position' value case sc.sbfl_status 
-                                   when 'running' then 'TopRight'
-                                   when 'waiting for message' then 'TopLeft'
+               key 'position' value case sc.badge_category
+                                   when 'running' then 'TopLeft'
+                                   when 'suspended' then 'TopRight'
                                    else 'BottomLeft'
                                  end,
                key 'shape' value 'circle',
                key 'label' value sc.numprocs,
-               key 'textColor' value '#000000',
-               key 'backgroundColor' value case sc.sbfl_status 
+               key 'textColor' value '#ffffff',
+               key 'backgroundColor' value case sc.badge_category 
                                            when 'running' then '#43A047'
-                                           when 'waiting for message' then '#FB8C00'
+                                           when 'suspended' then '#056ac8'
                                            else '#E53935'
                                          end
              )
@@ -47,6 +58,6 @@ select  d.dgrm_id,
         d.dgrm_content,
         bd.badges_data
 from flow_diagrams d
-join badges_data bd
+left outer join badges_data bd
 on   bd.dgrm_id = d.dgrm_id
 with read only;


### PR DESCRIPTION
fix P0019 view to show subflows in more states.
All waiting at (timer, message, gateway, approval,..) and in subprocess, in call activity states are now included in 'running' as this is normal operation of a model.