### PR TITLE
Add instance Logging Change feature to API& Engine app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,11 @@
   "editor.tabSize": 2,
   "githubPullRequests.ignoredPullRequestBranches": [
     "development"
+  ],
+  "spellright.language": [],
+  "spellright.documentTypes": [
+    "markdown",
+    "latex",
+    "plaintext"
   ]
 }

--- a/app_dist/RELEASE_NOTES.txt
+++ b/app_dist/RELEASE_NOTES.txt
@@ -1,6 +1,6 @@
 ***************************************************
 *                                                 *
-*            Flows for APEX v25.1                 *
+*            Flows for APEX v26.1                 *
 *             Community Edition                   *
 *          Installation instructions              *
 *              flowsforapex.org                   *
@@ -38,6 +38,10 @@ MIGRATING EXISTING INSTALLATIONS
 - Follow the instructions at https://flowsforapex.org/latest/migration/
 
 HISTORY
+* v26.1 Community Edition
+  - Adds the ability to change instance logging level of a running process instance using flow_admin_api.set_process_logging_level.
+  - Adds the ability to change instance logging level of a running process instance from the Action menu in the Flow Monitor details page.
+
 * v25.1 Community Edition
   - Adds GenAI Service Task.
   - Adds Error Boundary Events on Script tasks

--- a/src/plsql/engine-app/flow_engine_app_api.pkb
+++ b/src/plsql/engine-app/flow_engine_app_api.pkb
@@ -287,6 +287,12 @@ as
             , p_values => apex_application.g_x02||','||apex_application.g_x03
             , p_clear_cache => 'RP'
           );
+        when 'SET-PROCESS-LOGGING-LEVEL' then
+          flow_admin_api.set_process_logging_level
+          (
+            p_process_id     => apex_application.g_x02
+          , p_logging_level  => apex_application.g_x03
+          );  
         when 'EDIT-FLOW-DIAGRAM' then
           l_url := apex_page.get_url(
               p_page => 7

--- a/src/plsql/flow_admin_api.pkb
+++ b/src/plsql/flow_admin_api.pkb
@@ -412,6 +412,30 @@ The `flow_admin_api` package gives you access to the Flows for APEX engine admin
         raise;
   end flow_force_next_step;
 
+  procedure set_process_logging_level
+  ( p_process_id     in flow_processes.prcs_id%type
+  , p_logging_level  in flow_processes.prcs_logging_level%type
+  )
+  is
+    l_session_id   number;
+  begin     
+    if v('APP_SESSION') is null then
+      l_session_id := flow_apex_session.create_api_session (p_process_id => p_process_id);
+    end if;   
+
+    flow_instances.set_logging_level ( p_process_id     => p_process_id
+                                    , p_logging_level  => p_logging_level
+                                    );
+    if l_session_id is not null then
+      flow_apex_session.delete_session (p_session_id => l_session_id );
+    end if;   
+  exception
+      when others then
+        if l_session_id is not null then
+          flow_apex_session.delete_session (p_session_id => l_session_id );
+        end if;
+        raise;
+  end set_process_logging_level;
 
 end flow_admin_api;
 /

--- a/src/plsql/flow_admin_api.pks
+++ b/src/plsql/flow_admin_api.pks
@@ -257,5 +257,22 @@ The process instance does **not** need to be suspended to use this procedure.
 Available in Flows for APEX Enterprise Edition.
 **/
 
+  procedure set_process_logging_level
+  ( p_process_id        in flow_processes.prcs_id%type
+  , p_logging_level     in flow_processes.prcs_logging_level%type
+  );
+/**
+Procedure set_process_logging_level
+This procedure sets the logging level for a running process instance.
+The logging level determines the amount of logging that is performed for the process instance.
+Valid logging levels are:
+  - none - no logging is performed
+  - abnormal events - only logging of abnormal events (errors, warnings)
+  - major events - logging of major events (step completions, gateway decisions)
+  - routine - logging of all events except full variable values
+  - full - full / debug logging of all events including full variable values
+Available in Flows for APEX Community and Enterprise Edition.
+**/
+
 end flow_admin_api;
 /

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -282,6 +282,7 @@ as
   gc_prcs_event_leave_call            constant  varchar2(20 char) := 'finish called model';
   gc_prcs_event_priority_set          constant  varchar2(20 char) := 'priority set';
   gc_prcs_event_due_on_set            constant  varchar2(20 char) := 'due on set';
+  gc_prcs_event_logging_level_set     constant  varchar2(20 char) := 'logging level set';
   gc_prcs_event_warning               constant  varchar2(20 char) := 'warning';
   gc_prcs_event_sbfl_marked_delete    constant  varchar2(20 char) := 'subflow mark delete';
   gc_prcs_event_sbfl_deleted          constant  varchar2(20 char) := 'subflow deleted';
@@ -433,6 +434,8 @@ as
   gc_config_logging_level_standard           constant varchar2(2000 char) := 'standard';    -- instances and tasks
   gc_config_logging_level_secure             constant varchar2(2000 char) := 'secure';      -- standard + diagram changes
   gc_config_logging_level_full               constant varchar2(2000 char) := 'full';        -- secure + variable changes
+
+  
   gc_config_engine_app_mode_dev              constant varchar2(2000 char) := 'development';
   gc_config_engine_app_mode_prod             constant varchar2(2000 char) := 'production';
   gc_config_dup_step_prevention_legacy       constant varchar2(2000 char) := 'legacy';      -- null step key allowed

--- a/src/plsql/flow_instances.pkb
+++ b/src/plsql/flow_instances.pkb
@@ -1110,5 +1110,44 @@ create or replace package body flow_instances as
       where prcs.prcs_id = p_process_id;
   end set_was_altered;
 
+  procedure set_logging_level
+    (
+      p_process_id      in flow_processes.prcs_id%type
+    , p_logging_level  in flow_processes.prcs_logging_level%type
+    )
+  is
+  begin
+      -- check logging level is valid
+      if p_logging_level not in ( flow_constants_pkg.gc_logging_level_none
+                               , flow_constants_pkg.gc_logging_level_abnormal_events
+                               , flow_constants_pkg.gc_logging_level_major_events
+                               , flow_constants_pkg.gc_logging_level_routine
+                               , flow_constants_pkg.gc_logging_level_full)
+      then
+        flow_errors.handle_instance_error
+        ( pi_prcs_id        => p_process_id
+        , pi_message_key    => 'invalid-logging-level'
+        , p0                => p_logging_level       
+        );
+        -- $F4AMESSAGE 'invalid-logging-level' || 'Invalid logging level (%0) specified. Valid levels are none, abnormal_events, major_events, routine, full.'
+      end if; 
+      
+      update flow_processes prcs
+      set prcs.prcs_logging_level = p_logging_level
+        , prcs.prcs_last_update = systimestamp
+        , prcs.prcs_last_update_by = coalesce ( sys_context('apex$session','app_user') 
+                                              , sys_context('userenv','os_user')
+                                              , sys_context('userenv','session_user')
+                                              )  
+      where prcs.prcs_id = p_process_id;
+      -- log the logging level change
+      flow_logging.log_instance_event
+      ( p_process_id  => p_process_id
+      , p_event       => flow_constants_pkg.gc_prcs_event_logging_level_set
+      , p_event_level => flow_constants_pkg.gc_logging_level_major_events
+      , p_comment     => 'Process logging level set to '||p_logging_level
+      );      
+  end set_logging_level;  
+
 end flow_instances;
 /

--- a/src/plsql/flow_instances.pks
+++ b/src/plsql/flow_instances.pks
@@ -96,5 +96,11 @@ as
       p_process_id  in flow_processes.prcs_id%type
     );
 
+  procedure set_logging_level
+    (
+      p_process_id     in flow_processes.prcs_id%type
+    , p_logging_level  in flow_processes.prcs_logging_level%type
+    );
+
 end flow_instances;
 /


### PR DESCRIPTION
- Adds flow_admin_api.set_process_logging_level to change the logging level of a running process instance.
- Also adds UI support for this from the Engine pp - P8 Flow Monitor Details page -> Action Menu > Set Logging Level.