### PR TITLE
fix issue #861

### DIFF
--- a/doc/bug-861.bpmn
+++ b/doc/bug-861.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="25.1.0">
+  <bpmn:process id="Process_rpb6c02q" isExecutable="false" apex:minLoggingLevel="0" apex:manualInput="false">
+    <bpmn:startEvent id="Event_start" name="start">
+      <bpmn:outgoing>Flow_seqflow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_A" name="A">
+      <bpmn:incoming>Flow_seqflow1</bpmn:incoming>
+      <bpmn:outgoing>Flow_seqflow2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_seqflow1" name="seqflow1" sourceRef="Event_start" targetRef="Activity_A" apex:sequence="10" />
+    <bpmn:task id="Activity_B" name="B">
+      <bpmn:incoming>Flow_seqflow2</bpmn:incoming>
+      <bpmn:outgoing>Flow_seqflow3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_seqflow2" name="seqflow2" sourceRef="Activity_A" targetRef="Activity_B" apex:sequence="10" />
+    <bpmn:endEvent id="Event_end" name="end">
+      <bpmn:incoming>Flow_seqflow3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_seqflow3" name="seqflow3" sourceRef="Activity_B" targetRef="Event_end" apex:sequence="10" />
+    <bpmn:textAnnotation id="TextAnnotation_comment">
+      <bpmn:text>a comment</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_sf2_to_comment" associationDirection="None" sourceRef="Flow_seqflow2" targetRef="TextAnnotation_comment" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_rpb6c02q">
+      <bpmndi:BPMNShape id="Event_07ye9ws_di" bpmnElement="Event_start">
+        <dc:Bounds x="-698" y="-88" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-691" y="-45" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vofipx_di" bpmnElement="Activity_A">
+        <dc:Bounds x="-610" y="-110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09zo5pf_di" bpmnElement="Activity_B">
+        <dc:Bounds x="-350" y="-110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1d0u0q8_di" bpmnElement="Event_end">
+        <dc:Bounds x="-138" y="-88" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-129" y="-45" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0w4zp90_di" bpmnElement="Association_sf2_to_comment">
+        <di:waypoint x="-430" y="-70" />
+        <di:waypoint x="-364" y="-140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fz8mk7_di" bpmnElement="Flow_seqflow1">
+        <di:waypoint x="-662" y="-70" />
+        <di:waypoint x="-610" y="-70" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-658" y="-88" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0efyc9s_di" bpmnElement="Flow_seqflow2">
+        <di:waypoint x="-510" y="-70" />
+        <di:waypoint x="-350" y="-70" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-472" y="-88" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04g1l6p_di" bpmnElement="Flow_seqflow3">
+        <di:waypoint x="-250" y="-70" />
+        <di:waypoint x="-138" y="-70" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-216" y="-88" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_14lzxkv_di" bpmnElement="TextAnnotation_comment">
+        <dc:Bounds x="-400" y="-170" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/plsql/flow_bpmn_parser_pkg.pkb
+++ b/src/plsql/flow_bpmn_parser_pkg.pkb
@@ -451,35 +451,56 @@ as
     l_cur_conn_bpmn_id flow_types_pkg.t_bpmn_id;
     l_cur_conn         flow_parser_util.t_conn_rec;
     l_conn_id          flow_connections.conn_id%type;
+    l_src_objt_id      flow_connections.conn_src_objt_id%type;
+    l_tgt_objt_id      flow_connections.conn_tgt_objt_id%type;
   begin
 
     l_cur_conn_bpmn_id := g_connections.first;
     while l_cur_conn_bpmn_id is not null
     loop
       l_conn_id  := null;
+      l_src_objt_id := null;
+      l_tgt_objt_id := null;
       l_cur_conn := g_connections( l_cur_conn_bpmn_id );
 
-      -- verify if we know the IDs for source and target connection if set
-      -- anything strange stop all processing and raise error
-      if (  ( l_cur_conn.conn_src_bpmn_id is not null and not g_objt_lookup.exists( l_cur_conn.conn_src_bpmn_id ) )
-         or ( l_cur_conn.conn_tgt_bpmn_id is not null and not g_objt_lookup.exists( l_cur_conn.conn_tgt_bpmn_id ) )
-         )
-      then
-        raise_application_error(-20000, 'Connection Source or Target not found!');
-      else
-        insert_connection
-        (
-          pi_conn_bpmn_id      => l_cur_conn_bpmn_id
-        , pi_conn_name         => l_cur_conn.conn_name
-        , pi_conn_src_objt_id  => case when l_cur_conn.conn_src_bpmn_id is not null then g_objt_lookup( l_cur_conn.conn_src_bpmn_id ) else null end
-        , pi_conn_tgt_objt_id  => case when l_cur_conn.conn_tgt_bpmn_id is not null then g_objt_lookup( l_cur_conn.conn_tgt_bpmn_id ) else null end
-        , pi_conn_tag_name     => l_cur_conn.conn_tag_name
-        , pi_conn_origin       => l_cur_conn.conn_origin
-        , pi_conn_sequence     => l_cur_conn.conn_sequence
-        , pi_conn_attributes   => case when l_cur_conn.conn_attributes is not null then l_cur_conn.conn_attributes.to_clob else null end
-        , po_conn_id           => l_conn_id
-        );
+      -- associations may reference connection BPMN IDs (e.g. a sequenceFlow).
+      -- those endpoints cannot be stored in conn_*_objt_id, so we keep them null.
+      if l_cur_conn.conn_src_bpmn_id is not null then
+        if g_objt_lookup.exists( l_cur_conn.conn_src_bpmn_id ) then
+          l_src_objt_id := g_objt_lookup( l_cur_conn.conn_src_bpmn_id );
+        elsif l_cur_conn.conn_tag_name = flow_constants_pkg.gc_bpmn_association
+           and g_connections.exists( l_cur_conn.conn_src_bpmn_id )
+        then
+          null;
+        else
+          raise_application_error(-20000, 'Connection Source or Target not found!');
+        end if;
       end if;
+
+      if l_cur_conn.conn_tgt_bpmn_id is not null then
+        if g_objt_lookup.exists( l_cur_conn.conn_tgt_bpmn_id ) then
+          l_tgt_objt_id := g_objt_lookup( l_cur_conn.conn_tgt_bpmn_id );
+        elsif l_cur_conn.conn_tag_name = flow_constants_pkg.gc_bpmn_association
+           and g_connections.exists( l_cur_conn.conn_tgt_bpmn_id )
+        then
+          null;
+        else
+          raise_application_error(-20000, 'Connection Source or Target not found!');
+        end if;
+      end if;
+
+      insert_connection
+      (
+        pi_conn_bpmn_id      => l_cur_conn_bpmn_id
+      , pi_conn_name         => l_cur_conn.conn_name
+      , pi_conn_src_objt_id  => l_src_objt_id
+      , pi_conn_tgt_objt_id  => l_tgt_objt_id
+      , pi_conn_tag_name     => l_cur_conn.conn_tag_name
+      , pi_conn_origin       => l_cur_conn.conn_origin
+      , pi_conn_sequence     => l_cur_conn.conn_sequence
+      , pi_conn_attributes   => case when l_cur_conn.conn_attributes is not null then l_cur_conn.conn_attributes.to_clob else null end
+      , po_conn_id           => l_conn_id
+      );
 
       l_cur_conn_bpmn_id := g_connections.next( l_cur_conn_bpmn_id );
     end loop;

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -70,6 +70,7 @@ as
   gc_bpmn_gateway_event_based          constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'eventBasedGateway';
 
   gc_bpmn_sequence_flow                constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'sequenceFlow';
+  gc_bpmn_association                  constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'association';
 
   gc_bpmn_task                         constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'task';
   gc_bpmn_usertask                     constant flow_types_pkg.t_bpmn_id := gc_bpmn_prefix || 'userTask';


### PR DESCRIPTION
Fixes issue #861 where a diagram containing a bpmn:textAnnotation associated (using a (bpmn:association) to a sequenceFlow connection causes the diagram to fail in the bpmn parser.

As connections have connection-from and connection-to FKs to flow_objects, this fix leaves the connection to the sequenceFlow (which is stored in flow_connections, not flow_objects) as null.  This allows parsing to complete, results in the parsed diagram containing both the textAnnotation and the association - but without a FK link from one to the other.

The engine doesn't use textAnnotations for anything, and the BPMN diagram is still rendered correctly from the BPMN diagram - so I think this is satisfactory.

Rehression tests are included in the adhoc subprocesses branch.  Diagram parses OK and passes regression.