### PR TITLE
fix v26.1 migration 25.1 -> 26.1 skips schema annotations: `^ann_cmd.` executes a bare path as `Unknown Command`

### DIFF
--- a/src/migrations/25.1_to_26.1/migrate.sql
+++ b/src/migrations/25.1_to_26.1/migrate.sql
@@ -37,7 +37,7 @@ select case
            'no_annotations.sql'
        end as ann_cmd
   from dual;
-^ann_cmd.
+@@^ann_cmd.
 whenever sqlerror exit rollback
 
 @@set_flows_version.sql


### PR DESCRIPTION
Fixes #887